### PR TITLE
feat: 로그아웃 / 토큰 재발급 api 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ CONFIG_SERVER_URL=http://localhost:8888
 
 # Encryption key for {cipher} values
 ENCRYPT_KEY="{팀노션 .env 참고}"
+
+# Keycloak
+KEYCLOAK_CLIENT_SECRET=

--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -3,6 +3,7 @@ package com.firstticket.userservice.application;
 import java.util.UUID;
 
 import com.firstticket.userservice.application.dto.command.LoginCommand;
+import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
 import com.firstticket.userservice.application.dto.command.SignupCommand;
 import com.firstticket.userservice.application.dto.result.TokenResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
@@ -26,7 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 설계 결정 사항
  * - Application 계층은 domain 객체를 조율하는 역할만 담당 (로직은 Entity / VO 에서)
  * - KeycloakAuthService / RefreshTokenStore 는 Port 인터페이스를 통해 주입 (infrastructure 직접 의존 금지)
- * - login()은 DB 조회만 수행하므로 readOnly = true 로 최적화 (Redis 쓰기는 JPA 트랜잭션과 무관하게 동작)
+ * - login() / logout() / refreshToken()은 DB 조회만 수행하므로 readOnly = true 로 최적화
+ *   (Redis 쓰기는 JPA 트랜잭션과 무관하게 동작)
  */
 @Slf4j
 @Service
@@ -42,7 +44,7 @@ public class UserCommandService {
      * 처리 흐름
      * 1. VO 생성 → Email / Password 형식 검증 (실패 시 400 Bad Request)
      * 2. 이메일 중복 확인 (실패 시 409 Conflict)
-     * 3. Keycloak 계정 생성 → 비밀번호 해시 처리 위임, keycloakId 수신
+     * 3. Keycloak 계정 생성 -> 비밀번호 해시 처리 위임, keycloakId 수신
      * 4. User Entity 생성 / DB 저장
      * 5. UserResult 반환
      */
@@ -78,6 +80,12 @@ public class UserCommandService {
 
     /**
      * 로그인
+     * 처리 흐름
+     * 1. 이메일로 DB에서 사용자 조회 (없으면 401)
+     * 2. 계정 상태 검증 - ACTIVE 이외에는 로그인 거부
+     * 3. Keycloak ROPC 호출 → Access Token + Refresh Token 발급
+     * 4. Refresh Token Redis 저장
+     * 5. TokenResult 반환
      */
     @Transactional(readOnly = true)
     public TokenResult login(LoginCommand command) {
@@ -98,10 +106,90 @@ public class UserCommandService {
         // 3. Keycloak Token Endpoint 호출
         TokenResult tokenResult = keycloakAuthService.login(command.email(), command.password());
 
-        // 4. Refresh Token redis 키 저장
+        // 4. Refresh Token Redis 저장
         refreshTokenStore.save(user.getId(), tokenResult.refreshToken());
 
         // 5. AccessToken, RefreshToken 반환
         return tokenResult;
+    }
+
+    /**
+     * 로그아웃
+     * 처리 흐름
+     * 1. Gateway X-User-Id 헤더(keycloakId)로 사용자 조회
+     * 2. Redis에서 Refresh Token 삭제 (이후 토큰 재발급 불가)
+     *
+     * 설계 결정 사항
+     * - Access Token은 만료될 때까지 유효하지만 TTL이 짧으므로(통상 5~15분) 허용 범위로 간주
+     * - Keycloak 세션 revoke는 MVP 범위 외 (추후 /logout 엔드포인트 호출로 보완 가능)
+     */
+    @Transactional(readOnly = true)
+    public void logout(String keycloakId) {
+        // 1. keycloakId로 사용자 조회 (없으면 이미 삭제된 계정 또는 비정상 요청)
+        User user = userRepository.findByKeycloakId(keycloakId)
+            .orElseThrow(() -> {
+                log.warn("[logout] 사용자 조회 실패 - keycloakId: {}", keycloakId);
+                return new UserException(UserErrorCode.USER_NOT_FOUND);
+            });
+
+        // 2. Redis에서 Refresh Token 삭제 → 이후 재발급 불가
+        refreshTokenStore.delete(user.getId());
+        log.info("[logout] Refresh Token 삭제 완료 - userId: {}", user.getId());
+    }
+
+    /**
+     * 토큰 재발급 (Token Rotation)
+     * 처리 흐름
+     * 1. Refresh Token JWT payload에서 sub(keycloakId) 추출 (서명 검증 없이 payload만 디코딩)
+     * 2. keycloakId로 사용자 조회 + 상태 확인 (ACTIVE 필수)
+     * 3. Redis에서 저장된 Refresh Token 조회 → 없으면 로그아웃된 세션
+     * 4. 제공된 토큰 vs 저장된 토큰 비교 → 불일치 시 재사용 공격으로 간주하여 세션 전체 무효화
+     * 5. Keycloak에 Refresh Token Grant 요청 → 신규 토큰 쌍 발급
+     * 6. Redis rotate → 신규 Refresh Token으로 교체
+     * 7. 새 토큰 반환
+     */
+    @Transactional(readOnly = true)
+    public TokenResult refreshToken(RefreshTokenCommand command) {
+        // 1. Refresh Token JWT payload에서 sub 추출
+        String keycloakId = keycloakAuthService.extractSubject(command.refreshToken());
+
+        // 2. keycloakId로 사용자 조회
+        User user = userRepository.findByKeycloakId(keycloakId)
+            .orElseThrow(() -> {
+                log.warn("[refreshToken] 사용자 조회 실패 - keycloakId: {}", keycloakId);
+                return new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+            });
+
+        // ACTIVE 이외의 계정은 토큰 재발급 거부 (LOCKED, DELETED 포함)
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            log.warn("[refreshToken] 계정 비활성 상태 - userId: {}, status: {}", user.getId(), user.getStatus());
+            throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 3. Redis에서 저장된 Refresh Token 조회
+        // 토큰이 없다면 로그아웃 또는 TTL 만료 -> 재로그인 필요
+        String storedToken = refreshTokenStore.find(user.getId())
+            .orElseThrow(() -> {
+                log.warn("[refreshToken] Redis에 토큰 없음 (로그아웃 또는 만료) - userId: {}", user.getId());
+                return new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+            });
+
+        // 4. 제공된 토큰과 저장된 토큰 비교
+        // 불일치: 이미 rotate된 구 토큰을 사용하는 경우 → 탈취 의심
+        // 대응: 기존 세션을 즉시 무효화하여 피해 최소화 (합법 사용자도 재로그인 필요)
+        if (!storedToken.equals(command.refreshToken())) {
+            log.warn("[refreshToken] 토큰 불일치 감지 - 재사용 공격 의심, 세션 무효화. userId: {}", user.getId());
+            refreshTokenStore.delete(user.getId()); // 기존 세션 강제 종료
+            throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 5. Keycloak에 신규 토큰 발급 요청 (Keycloak이 기존 Refresh Token을 자동 무효화)
+        TokenResult newTokens = keycloakAuthService.refreshToken(command.refreshToken());
+
+        // 6. Redis에 신규 Refresh Token으로 교체 (원자적 덮어쓰기)
+        refreshTokenStore.rotate(user.getId(), newTokens.refreshToken());
+
+        // 7. 새로 발급된 토큰 반환
+        return newTokens;
     }
 }

--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -16,6 +16,7 @@ import com.firstticket.userservice.domain.exception.UserErrorCode;
 import com.firstticket.userservice.domain.exception.UserException;
 import com.firstticket.userservice.domain.service.KeycloakAuthService;
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
+import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult; // ← 추가
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,23 +45,23 @@ public class UserCommandService {
      * 처리 흐름
      * 1. VO 생성 → Email / Password 형식 검증 (실패 시 400 Bad Request)
      * 2. 이메일 중복 확인 (실패 시 409 Conflict)
-     * 3. Keycloak 계정 생성 -> 비밀번호 해시 처리 위임, keycloakId 수신
+     * 3. Keycloak 계정 생성 → 비밀번호 해시 처리 위임, keycloakId 수신
      * 4. User Entity 생성 / DB 저장
      * 5. UserResult 반환
      */
     @Transactional
     public UserResult signup(SignupCommand command) {
-        // 1. VO 생성 (VO 생성자에서 형식 검증 - 실패 시 UserException 발생 → 400)
+        // 1. VO 생성 (VO 생성자에서 형식 검증 — 실패 시 UserException 발생 → 400)
         Email email = Email.of(command.email());
         Password password = Password.of(command.password()); // 검증 후 Keycloak에 전달하고 버림
 
-        // 2. 이메일 중복 확인 (DB 레벨에서 우선 차단 - Keycloak 호출 전에 확인하여 불필요한 외부 호출 방지)
+        // 2. 이메일 중복 확인 (DB 레벨에서 우선 차단 — Keycloak 호출 전에 확인하여 불필요한 외부 호출 방지)
         if (userRepository.existsByEmail(email.value())) {
             throw new UserException(UserErrorCode.DUPLICATE_EMAIL);
         }
 
         // 3. Keycloak Admin Client를 통해 Realm에 사용자 생성 (비밀번호 해시 처리 위임)
-        // keycloakId = Keycloak 이 발급한 사용자 UUID (JWT sub claim 과 동일)
+        // keycloakId = Keycloak이 발급한 사용자 UUID (JWT sub claim과 동일)
         String keycloakId = keycloakAuthService.createUser(
             email.value(),
             password.value(),
@@ -70,7 +71,7 @@ public class UserCommandService {
         // 4. User 엔티티 생성 (role: CUSTOMER 고정, status: ACTIVE 고정)
         User user = User.create(keycloakId, email, command.username());
 
-        // Keycloak 에서 받은 자신의 UUID 를 created_by 에 직접 주입
+        // Keycloak에서 받은 자신의 UUID를 created_by에 직접 주입
         user.initCreatedBy(UUID.fromString(keycloakId));
 
         // 5. DB 저장 후 Result DTO 반환
@@ -82,7 +83,7 @@ public class UserCommandService {
      * 로그인
      * 처리 흐름
      * 1. 이메일로 DB에서 사용자 조회 (없으면 401)
-     * 2. 계정 상태 검증 - ACTIVE 이외에는 로그인 거부
+     * 2. 계정 상태 검증 — ACTIVE 이외에는 로그인 거부
      * 3. Keycloak ROPC 호출 → Access Token + Refresh Token 발급
      * 4. Refresh Token Redis 저장
      * 5. TokenResult 반환
@@ -96,8 +97,8 @@ public class UserCommandService {
                 return new UserException(UserErrorCode.INVALID_CREDENTIALS);
             });
 
-        // 2. 계정 상태 검증 : 'ACTIVE' 이외에는 로그인 실패
-        // LOCKED: 잠김 / DELETED : 탈퇴처리
+        // 2. 계정 상태 검증: ACTIVE 이외에는 로그인 실패
+        // LOCKED: 잠김 / DELETED: 탈퇴 처리
         if (user.getStatus() != UserStatus.ACTIVE) {
             log.warn("[login] 계정 비활성 상태 - userId: {}, status: {}", user.getId(), user.getStatus());
             throw new UserException(UserErrorCode.INVALID_CREDENTIALS);
@@ -140,17 +141,18 @@ public class UserCommandService {
     /**
      * 토큰 재발급 (Token Rotation)
      * 처리 흐름
-     * 1. Refresh Token JWT payload에서 sub(keycloakId) 추출 (서명 검증 없이 payload만 디코딩)
-     * 2. keycloakId로 사용자 조회 + 상태 확인 (ACTIVE 필수)
-     * 3. Redis에서 저장된 Refresh Token 조회 → 없으면 로그아웃된 세션
-     * 4. 제공된 토큰 vs 저장된 토큰 비교 → 불일치 시 재사용 공격으로 간주하여 세션 전체 무효화
-     * 5. Keycloak에 Refresh Token Grant 요청 → 신규 토큰 쌍 발급
-     * 6. Redis rotate → 신규 Refresh Token으로 교체
-     * 7. 새 토큰 반환
+     * 1. Refresh Token JWT payload에서 sub(keycloakId) 추출
+     *    ⚠서명 검증 없이 payload만 디코딩 - 사용자 식별용 라우팅 힌트로만 사용
+     *    실제 토큰 유효성 검증은 Keycloak refreshToken() 호출에서 수행
+     * 2. keycloakId로 사용자 조회 + ACTIVE 상태 확인
+     * 3. Keycloak에 신규 토큰 발급 요청
+     * 4. Redis Lua CAS rotate - oldToken 검증 + newToken 교체를 원자적으로 처리
+     *    (동시 요청 시 하나만 성공, 불일치 시 세션 삭제 없이 예외만 반환)
+     * 5. 새 토큰 반환
      */
     @Transactional(readOnly = true)
     public TokenResult refreshToken(RefreshTokenCommand command) {
-        // 1. Refresh Token JWT payload에서 sub 추출
+        // 1. Refresh Token JWT payload에서 sub 추출 (서명 검증 없음 — 라우팅 힌트용)
         String keycloakId = keycloakAuthService.extractSubject(command.refreshToken());
 
         // 2. keycloakId로 사용자 조회
@@ -166,30 +168,31 @@ public class UserCommandService {
             throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 3. Redis에서 저장된 Refresh Token 조회
-        // 토큰이 없다면 로그아웃 또는 TTL 만료 -> 재로그인 필요
-        String storedToken = refreshTokenStore.find(user.getId())
-            .orElseThrow(() -> {
-                log.warn("[refreshToken] Redis에 토큰 없음 (로그아웃 또는 만료) - userId: {}", user.getId());
-                return new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
-            });
-
-        // 4. 제공된 토큰과 저장된 토큰 비교
-        // 불일치: 이미 rotate된 구 토큰을 사용하는 경우 → 탈취 의심
-        // 대응: 기존 세션을 즉시 무효화하여 피해 최소화 (합법 사용자도 재로그인 필요)
-        if (!storedToken.equals(command.refreshToken())) {
-            log.warn("[refreshToken] 토큰 불일치 감지 - 재사용 공격 의심, 세션 무효화. userId: {}", user.getId());
-            refreshTokenStore.delete(user.getId()); // 기존 세션 강제 종료
-            throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
-        }
-
-        // 5. Keycloak에 신규 토큰 발급 요청 (Keycloak이 기존 Refresh Token을 자동 무효화)
+        // 3. Keycloak 신규 토큰 발급 (Keycloak이 refreshToken 서명/만료 검증 담당)
         TokenResult newTokens = keycloakAuthService.refreshToken(command.refreshToken());
 
-        // 6. Redis에 신규 Refresh Token으로 교체 (원자적 덮어쓰기)
-        refreshTokenStore.rotate(user.getId(), newTokens.refreshToken());
+        // 4. Redis Lua CAS rotate - 원자적으로 oldToken 검증 + newToken 교체
+        // 동시 요청이 두 개 들어와도 하나만 성공하도록 보장
+        RotateResult rotateResult = refreshTokenStore.rotate(
+            user.getId(),
+            command.refreshToken(),   // oldToken
+            newTokens.refreshToken()  // newToken
+        );
 
-        // 7. 새로 발급된 토큰 반환
+        switch (rotateResult) {
+            case NOT_FOUND -> {
+                // 로그아웃 또는 TTL 만료 - 재로그인 필요
+                log.warn("[refreshToken] Redis 토큰 없음 (로그아웃 or 만료) - userId: {}", user.getId());
+                throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            case TOKEN_MISMATCH -> {
+                // 이미 rotate된 구 토큰 사용 - 재사용 공격 의심
+                log.warn("[refreshToken] 토큰 불일치 감지 - 재사용 공격 의심. userId: {}", user.getId());
+                throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            case SUCCESS -> log.info("[refreshToken] 토큰 재발급 성공 - userId: {}", user.getId());
+        }
+
         return newTokens;
     }
 }

--- a/src/main/java/com/firstticket/userservice/application/dto/command/RefreshTokenCommand.java
+++ b/src/main/java/com/firstticket/userservice/application/dto/command/RefreshTokenCommand.java
@@ -1,0 +1,5 @@
+package com.firstticket.userservice.application.dto.command;
+
+public record RefreshTokenCommand(
+    String refreshToken
+) {}

--- a/src/main/java/com/firstticket/userservice/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/firstticket/userservice/domain/exception/UserErrorCode.java
@@ -23,7 +23,10 @@ public enum UserErrorCode implements ErrorCode {
     // ===== HostRequest =====
     HOST_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "HOST 신청 요청을 찾을 수 없습니다."),
     INVALID_HOST_REQUEST_STATUS(HttpStatus.BAD_REQUEST, "허용되지 않은 HOST 신청 상태 전이입니다."),
-    HOST_REQUEST_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 검토 중인 HOST 신청이 존재합니다.");
+    HOST_REQUEST_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 검토 중인 HOST 신청이 존재합니다."),
+
+    // Token
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/userservice/domain/service/KeycloakAuthService.java
+++ b/src/main/java/com/firstticket/userservice/domain/service/KeycloakAuthService.java
@@ -20,4 +20,16 @@ public interface KeycloakAuthService {
      * Access Token + Refresh Token 을 발급받습니다.
      */
     TokenResult login(String email, String password);
+
+    TokenResult refreshToken(String refreshToken);
+
+    /**
+     * JWT 토큰 payload에서 sub(subject) 클레임 추출
+     *
+     * 설계 결정 사항
+     * - PUBLIC 엔드포인트 (/token/refresh)에서는 Gateway X-User-Id 헤더가 없으므로
+     * - Refresh Token JWT payload를 직접 디코딩하여 keycloakId를 추출합니다.
+     * - 서명 검은은 이후 keycloak refreshToken() 호출 시 keycloak이 담당
+     */
+    String extractSubject(String jwtToken);
 }

--- a/src/main/java/com/firstticket/userservice/domain/service/RefreshTokenStore.java
+++ b/src/main/java/com/firstticket/userservice/domain/service/RefreshTokenStore.java
@@ -23,7 +23,13 @@ public interface RefreshTokenStore {
     // Refresh Token 삭제 (로그아웃, 재발급 후 기존 토큰 무효화 로직)
     void delete(UUID userId);
 
-    // Token Rotation : 기존 Refresh Token을 신규 토큰으로 교체
-    // 동일 키를 단일 SET 명령으로 덮어씀. (TTL도 갱신)
-    void rotate(UUID userId, String newRefreshToken);
+    // 기존 rotate(newToken) 제거 -> CAS 방식으로 교체
+    // oldToken 일치 확인 + 신규 토큰 저장을 Redis에서 원자적으로 처리
+    RotateResult rotate(UUID userId, String oldToken, String newToken);
+
+    enum RotateResult {
+        SUCCESS, // 정상 교체
+        NOT_FOUND, // 키 없음 (로그아웃 or TTL 만료)
+        TOKEN_MISMATCH // 토큰 불일치 (재사용 공격 의심)
+    }
 }

--- a/src/main/java/com/firstticket/userservice/domain/service/RefreshTokenStore.java
+++ b/src/main/java/com/firstticket/userservice/domain/service/RefreshTokenStore.java
@@ -22,4 +22,8 @@ public interface RefreshTokenStore {
 
     // Refresh Token 삭제 (로그아웃, 재발급 후 기존 토큰 무효화 로직)
     void delete(UUID userId);
+
+    // Token Rotation : 기존 Refresh Token을 신규 토큰으로 교체
+    // 동일 키를 단일 SET 명령으로 덮어씀. (TTL도 갱신)
+    void rotate(UUID userId, String newRefreshToken);
 }

--- a/src/main/java/com/firstticket/userservice/infrastructure/provider/KeycloakAuthServiceImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/provider/KeycloakAuthServiceImpl.java
@@ -1,8 +1,14 @@
 package com.firstticket.userservice.infrastructure.provider;
 
-import java.util.List;
-import java.util.UUID;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstticket.userservice.application.dto.result.TokenResult;
+import com.firstticket.userservice.domain.exception.UserErrorCode;
+import com.firstticket.userservice.domain.exception.UserException;
+import com.firstticket.userservice.domain.service.KeycloakAuthService;
+import jakarta.ws.rs.core.Response;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -12,15 +18,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.firstticket.userservice.application.dto.result.TokenResult;
-import com.firstticket.userservice.domain.exception.UserErrorCode;
-import com.firstticket.userservice.domain.exception.UserException;
-import com.firstticket.userservice.domain.service.KeycloakAuthService;
-
-import jakarta.ws.rs.core.Response;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * domain 계층의 KeycloakAuthService (Port) 의 Adapter 구현체
@@ -28,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
  *
  * createUser: Keycloak Admin Client (Admin REST API) -> 사용자 생성
  * login: RestClient -> Token Endpoint (ROPC)
+ * refreshToken: RestClient -> Token Endpoint (Refresh Token Grant)
+ * extractSubject: JWT payload Base64 디코딩 -> sub 클레임 추출
  */
 @Slf4j
 @Service
@@ -35,8 +38,9 @@ import lombok.extern.slf4j.Slf4j;
 public class KeycloakAuthServiceImpl implements KeycloakAuthService {
 
     private final Keycloak keycloakAdminClient;
-    private final RestClient keycloakRestClient; // Token Endpoint용 HTTP 클라이언트
+    private final RestClient keycloakRestClient;
     private final KeycloakProperties keycloakProperties;
+    private final ObjectMapper objectMapper;
 
     @Override
     public String createUser(String email, String plainPassword, String username) {
@@ -100,11 +104,7 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
     @Override
     public TokenResult login(String email, String password) {
         // Token Endpoint URL : {serverUrl}/realms/{realm}/protocol/openid-connect/token
-        String tokenUrl = String.format(
-            "%s/realms/%s/protocol/openid-connect/token",
-            keycloakProperties.serverUrl(),
-            keycloakProperties.realm()
-        );
+        String tokenUrl = buildTokenUrl();
 
         // OAuth2 Resource Owner Password Credentials Grant 요청 (ROPC)
         MultiValueMap<String, String> formBody = new LinkedMultiValueMap<>();
@@ -114,6 +114,34 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
         formBody.add("username", email);
         formBody.add("password", password); // 평문 패스워드 (TLS 보호)
 
+        return requestToken(tokenUrl, formBody, UserErrorCode.INVALID_CREDENTIALS);
+    }
+
+    @Override
+    public TokenResult refreshToken(String refreshToken) {
+        // Token Endpoint URL (login과 동일한 엔드포인트, grant_type만 다름)
+        String tokenUrl = buildTokenUrl();
+
+        // OAuth2 Refresh Token Grant 요청
+        MultiValueMap<String, String> formBody = new LinkedMultiValueMap<>();
+        formBody.add("grant_type", "refresh_token");
+        formBody.add("client_id", keycloakProperties.clientId());
+        formBody.add("client_secret", keycloakProperties.clientSecret());
+        formBody.add("refresh_token", refreshToken);
+
+        return requestToken(tokenUrl, formBody, UserErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    /**
+     * Keycloak Token Endpoint 공통 호출 로직
+     *
+     * 설계 결정 사항
+     * - login()과 refreshToken()은 동일한 Token Endpoint를 호출하므로 공통 메서드로 추출
+     * - 4xx 오류 시 던질 에러 코드를 파라미터로 받아 호출자가 의미를 결정합니다.
+     *   (login → INVALID_CREDENTIALS, refreshToken → INVALID_REFRESH_TOKEN)
+     */
+    private TokenResult requestToken(String tokenUrl, MultiValueMap<String, String> formBody,
+        UserErrorCode credentialErrorCode) {
         try {
             // Content-Type: application/x-www-form-urlencoded로 Token Endpoint 호출
             KeycloakTokenResponse response = keycloakRestClient.post()
@@ -121,16 +149,14 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(formBody)
                 .retrieve()
-                // 401 Unauthorized > 자격증명 불일치
                 .onStatus(
                     status -> status.value() == 400 || status.value() == 401,
                     (req, res) -> {
                         log.warn("Keycloak 자격증명 오류 - status: {}", res.getStatusCode());
-                        throw new UserException(UserErrorCode.INVALID_CREDENTIALS);
+                        throw new UserException(credentialErrorCode);
                     }
                 )
                 // 5xx Server Error -> Keycloak 서버 장애
-                // 400 등 기타 오류는 하단 catch에서 포착
                 .onStatus(
                     status -> status.is5xxServerError(),
                     (req, res) -> {
@@ -140,13 +166,12 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
                 )
                 .body(KeycloakTokenResponse.class); // access token, refresh token 역직렬화
 
+            // 정상 응답이지만 body가 없는 비정상 케이스 방어
             if (response == null) {
-                // 정상 응답이지만 body가 없는 비정상 케이스 방어
                 log.error("Keycloak Token Endpoint 응답 body가 null입니다.");
                 throw new RuntimeException("Keycloak 토큰 발급 응답이 올바르지 않습니다.");
             }
 
-            // [Issue 2 반영] accessToken / refreshToken null·blank 검증
             // null이나 빈 토큰이 Redis에 저장되면 재발급 흐름에서 무결성 오류 발생
             if (response.accessToken() == null || response.accessToken().isBlank()
                 || response.refreshToken() == null || response.refreshToken().isBlank()) {
@@ -164,10 +189,55 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
-            // 네트워크 오류, 타임아웃 등 checked 예외 → 로깅 후 RuntimeException으로 전환
+            // 네트워크 오류, 타임아웃 등 checked 예외 -> 로깅 후 RuntimeException으로 전환
             log.error("Keycloak Token Endpoint 호출 중 오류 발생", e);
             throw new RuntimeException("Keycloak 토큰 발급 중 오류가 발생했습니다.", e);
         }
+    }
+
+    @Override
+    public String extractSubject(String jwtToken) {
+        // JWT 구조: {header}.{payload}.{signature} (각 파트는 Base64URL 인코딩)
+        try {
+            String[] parts = jwtToken.split("\\.");
+            if (parts.length != 3) {
+                // JWT 형식이 아닌 토큰 또는 변조된 토큰 필터링
+                throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+            }
+
+            // JWT Base64URL은 패딩(=) 없이 인코딩됨 → Java 디코더 호환을 위해 패딩 복원
+            String paddedPayload = addPadding(parts[1]);
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(paddedPayload);
+
+            // payload JSON에서 sub 클레임 추출
+            @SuppressWarnings("unchecked")
+            Map<String, Object> claims = objectMapper.readValue(payloadBytes, Map.class);
+            String sub = (String) claims.get("sub");
+
+            if (sub == null || sub.isBlank()) {
+                log.warn("Refresh Token sub 클레임이 존재하지 않습니다.");
+                throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            return sub;
+        } catch (UserException e) {
+            throw e;
+        } catch (Exception e) {
+            // Base64 디코딩 실패, JSON 파싱 실패 등 -> 변조 또는 잘못된 형식의 토큰
+            log.warn("Refresh Token sub 클레임 추출 실패 - 토큰 형식 오류", e);
+            throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * Base64URL 문자열에 JWT 표준에서 생략된 패딩(=)을 복원합니다.
+     * Java의 Base64.getUrlDecoder()는 패딩이 있어야 정상 동작하므로 필요합니다.
+     */
+    private String addPadding(String base64Url) {
+        // base64url 인코딩된 문자열 길이는 4의 배수여야 함
+        int remainder = base64Url.length() % 4;
+        if (remainder == 2) return base64Url + "=="; // 2글자 부족
+        if (remainder == 3) return base64Url + "=";  // 1글자 부족
+        return base64Url;
     }
 
     /**
@@ -177,6 +247,17 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
     private record KeycloakTokenResponse(
         @JsonProperty("access_token") String accessToken,
         @JsonProperty("refresh_token") String refreshToken
-    ) {
+    ) {}
+
+    /**
+     * Keycloak Token Endpoint URL을 생성합니다.
+     * login, refreshToken 두 메서드에서 동일하게 사용합니다.
+     */
+    private String buildTokenUrl() {
+        return String.format(
+            "%s/realms/%s/protocol/openid-connect/token",
+            keycloakProperties.serverUrl(),
+            keycloakProperties.realm()
+        );
     }
 }

--- a/src/main/java/com/firstticket/userservice/infrastructure/redis/RefreshTokenStoreImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/redis/RefreshTokenStoreImpl.java
@@ -1,11 +1,13 @@
 package com.firstticket.userservice.infrastructure.redis;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
 
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
 
@@ -15,64 +17,84 @@ import lombok.RequiredArgsConstructor;
  * domain/service/RefreshTokenStore 구현체
  *
  * 설계 결정 사항
- * - StringRedisTemplate 사용 - 값이 단순 String이므로 RedisTemplate에 비해 가볍고 직관적
- * - Redis key 패턴 : "refresh:{userId}" -> 사용자당 하나의 refresh Token만 유지 (단일 세션 정책)
+ * - StringRedisTemplate 사용 — 값이 단순 String이므로 RedisTemplate에 비해 가볍고 직관적
+ * - Redis key 패턴: "refresh:{userId}" → 사용자당 하나의 Refresh Token만 유지 (단일 세션 정책)
  * - Refresh Token TTL 7일
- * - @Repository : infrastructure 계층의 데이터 접근 컴포넌트 명시
  */
-
-@Repository
+@Component
 @RequiredArgsConstructor
 public class RefreshTokenStoreImpl implements RefreshTokenStore {
 
     private final StringRedisTemplate redisTemplate;
 
-    // Redis key prefix
-    private static final String KEY_PREFIX = "refresh:";
+    private static final String ROTATE_SCRIPT =
+        "local stored = redis.call('GET', KEYS[1]) " +
+            "if stored == false then return -1 end " +
+            "if stored ~= ARGV[1] then return 0 end " +
+            "redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3]) " +
+            "return 1";
 
-    // Refresh Token TTL - Keycloak 설정과 동기화 (기본 7일)
-    private static final long TTL_DAYS = 7L;
+    private static final long REFRESH_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60L;
 
     /**
-     * Refresh Token을 key로 Redis에 저장
-     * 동일 userId에 이미 토큰이 있다면 덮어쓰기합니다. (TTL도 갱신)
+     * Refresh Token을 Redis에 저장
+     * 동일 userId에 이미 토큰이 있다면 덮어쓰기 (TTL도 갱신)
      */
     @Override
     public void save(UUID userId, String refreshToken) {
         redisTemplate.opsForValue().set(
-            KEY_PREFIX + userId,
+            buildKey(userId),              // "refresh:{userId}"
             refreshToken,
-            TTL_DAYS,
-            TimeUnit.DAYS
+            REFRESH_TOKEN_TTL_SECONDS,
+            TimeUnit.SECONDS
         );
     }
 
     /**
-     * 저장된 Refresh Token을 조회
+     * 저장된 Refresh Token 조회
      * 토큰이 없거나 TTL 만료인 경우 Optional.empty() 반환
      */
     @Override
     public Optional<String> find(UUID userId) {
-        return Optional.ofNullable(redisTemplate.opsForValue().get(KEY_PREFIX + userId));
+        return Optional.ofNullable(
+            redisTemplate.opsForValue().get(buildKey(userId))
+        );
     }
 
     /**
      * Refresh Token 삭제
-     * 로그아웃 또는 토큰 재발급시 기존 토큰 무효화
+     * 로그아웃 또는 세션 무효화 시 사용
      */
     @Override
     public void delete(UUID userId) {
-        redisTemplate.delete(KEY_PREFIX + userId);
+        redisTemplate.delete(buildKey(userId)); // KEY_PREFIX 미정의 → buildKey()로 통일
     }
 
     /**
-     * Token Rotation
-     *
-     * 설계 결정 사항
-     * - 동일 키 ("refresh:{userId}")를 Redis SET 단일 명령으로 덮어씀
+     * Token Rotation — Lua CAS (Compare-And-Swap)
+     * oldToken 일치 확인 + newToken 저장을 Redis에서 원자적으로 처리
+     * 동시 요청이 들어와도 하나만 성공하도록 보장
      */
     @Override
-    public void rotate(UUID userId, String newRefreshToken) {
-        save(userId, newRefreshToken);
+    public RotateResult rotate(UUID userId, String oldToken, String newToken) {
+        RedisScript<Long> script = RedisScript.of(ROTATE_SCRIPT, Long.class);
+
+        Long result = redisTemplate.execute(
+            script,
+            List.of(buildKey(userId)),
+            oldToken,
+            newToken,
+            String.valueOf(REFRESH_TOKEN_TTL_SECONDS)
+        );
+
+        // Lua 반환값 → enum 매핑
+        if (result == null || result == -1L) return RotateResult.NOT_FOUND;
+        if (result == 0L)                    return RotateResult.TOKEN_MISMATCH;
+        return RotateResult.SUCCESS;
+    }
+
+    // Redis key 생성
+    private String buildKey(UUID userId) {
+        return "refresh:" + userId;
     }
 }

--- a/src/main/java/com/firstticket/userservice/infrastructure/redis/RefreshTokenStoreImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/redis/RefreshTokenStoreImpl.java
@@ -64,4 +64,15 @@ public class RefreshTokenStoreImpl implements RefreshTokenStore {
     public void delete(UUID userId) {
         redisTemplate.delete(KEY_PREFIX + userId);
     }
+
+    /**
+     * Token Rotation
+     *
+     * 설계 결정 사항
+     * - 동일 키 ("refresh:{userId}")를 Redis SET 단일 명령으로 덮어씀
+     */
+    @Override
+    public void rotate(UUID userId, String newRefreshToken) {
+        save(userId, newRefreshToken);
+    }
 }

--- a/src/main/java/com/firstticket/userservice/presentation/AuthController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/AuthController.java
@@ -20,16 +20,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Auth(인증) 관련 API 컨트롤러
- * Gateway SecurityConfig의 PUBLIC_PATHS에 등록된 경로 담당 (인증 불필요)
- *
- * 담당 엔드포인트:
- *   POST /api/v1/auth/signup         - 회원가입
- *   POST /api/v1/auth/login          - 로그인
- *   POST /api/v1/auth/logout         - 로그아웃 (X-User-Id 헤더 필요)
- *   POST /api/v1/auth/token/refresh  - 토큰 재발급 (PUBLIC — 인증 불필요)
- */
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor

--- a/src/main/java/com/firstticket/userservice/presentation/AuthController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/AuthController.java
@@ -5,6 +5,7 @@ import com.firstticket.userservice.application.UserCommandService;
 import com.firstticket.userservice.application.dto.result.TokenResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
 import com.firstticket.userservice.presentation.dto.request.LoginRequest;
+import com.firstticket.userservice.presentation.dto.request.RefreshTokenRequest;
 import com.firstticket.userservice.presentation.dto.request.SignupRequest;
 import com.firstticket.userservice.presentation.dto.response.TokenResponse;
 import com.firstticket.userservice.presentation.dto.response.UserResponse;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,10 +25,11 @@ import org.springframework.web.bind.annotation.RestController;
  * Gateway SecurityConfig의 PUBLIC_PATHS에 등록된 경로 담당 (인증 불필요)
  *
  * 담당 엔드포인트:
- *   POST /api/v1/auth/signup - 회원가입
- *   POST /api/v1/auth/login  - 로그인
+ *   POST /api/v1/auth/signup         - 회원가입
+ *   POST /api/v1/auth/login          - 로그인
+ *   POST /api/v1/auth/logout         - 로그아웃 (X-User-Id 헤더 필요)
+ *   POST /api/v1/auth/token/refresh  - 토큰 재발급 (PUBLIC — 인증 불필요)
  */
-
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -43,7 +46,6 @@ public class AuthController {
      * 오류 응답:
      *   400 Bad Request — 입력값 형식 오류 (@NotBlank 위반, Email/Password VO 검증 실패)
      *   409 Conflict    — 이미 사용 중인 이메일
-     *   추후 docs로 교체 예정
      */
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserResponse>> signup(
@@ -79,6 +81,58 @@ public class AuthController {
 
         return ApiResponse.success(
             UserSuccessCode.LOGIN_SUCCESS,
+            TokenResponse.from(result)
+        );
+    }
+
+    /**
+     * 로그아웃 API
+     * Gateway에서 주입한 X-User-Id 헤더(keycloakId)를 사용하여 Redis의 Refresh Token을 삭제합니다.
+     *
+     * @param keycloakId Gateway AuthorizationHeaderFilter가 JWT sub 클레임에서 추출하여 주입
+     * @return 204 No Content
+     *
+     * 오류 응답:
+     *   404 Not Found — 존재하지 않는 사용자 (정상적인 요청에서는 발생하지 않음)
+     *
+     * 설계 결정 사항
+     * - Access Token은 만료될 때까지 유효하지만 TTL이 짧으므로(통상 5~15분) 허용 범위로 간주
+     * - Refresh Token만 삭제하여 재발급 경로를 차단하는 방식 채택
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+        @RequestHeader("X-User-Id") String keycloakId) {
+
+        userCommandService.logout(keycloakId);
+
+        // 204 No Content — 응답 body 없음 (RESTful 관례: 삭제/무효화 성공 시 본문 생략)
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 토큰 재발급 API (Token Rotation)
+     * Refresh Token으로 새로운 Access Token + Refresh Token 쌍을 발급합니다.
+     * 기존 Refresh Token은 즉시 무효화됩니다. (replay attack 방지)
+     *
+     * @param request refreshToken (필수)
+     * @return 200 OK + { accessToken, refreshToken }
+     *
+     * 오류 응답:
+     *   400 Bad Request  — refreshToken 빈 값 (@NotBlank 위반)
+     *   401 Unauthorized — 유효하지 않은 Refresh Token (만료, 로그아웃, 재사용 공격 감지)
+     *
+     * 설계 결정 사항
+     * - Gateway PUBLIC_PATHS 등록 경로 → X-User-Id 헤더 없음
+     * - Refresh Token JWT payload에서 sub(keycloakId)를 추출하여 사용자 식별
+     */
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refreshToken(
+        @Valid @RequestBody RefreshTokenRequest request) {
+
+        TokenResult result = userCommandService.refreshToken(request.toCommand());
+
+        return ApiResponse.success(
+            UserSuccessCode.TOKEN_REFRESHED,
             TokenResponse.from(result)
         );
     }

--- a/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
@@ -15,6 +15,7 @@ public enum UserSuccessCode implements SuccessCode {
 
     USER_CREATED(HttpStatus.CREATED, "회원가입이 완료되었습니다."), // 201
     LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"), // 200
+    TOKEN_REFRESHED(HttpStatus.OK, "토큰이 재발급되었습니다."), // 200
     USER_FOUND(HttpStatus.OK, "사용자 정보를 조회했습니다."); // 200
 
     private final HttpStatus status;

--- a/src/main/java/com/firstticket/userservice/presentation/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/firstticket/userservice/presentation/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package com.firstticket.userservice.presentation.dto.request;
+
+import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+    @NotBlank(message = "refreshToken은 필수입니다.")
+    String refreshToken
+) {
+    public RefreshTokenCommand toCommand() {
+        return new RefreshTokenCommand(refreshToken);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,3 @@
-server:
-  port: 8081  # user-service 고정 포트
-
 spring:
   application:
     name: user-service  # Eureka 등록명 / Config Server 설정 경로명으로 사용
@@ -15,38 +12,3 @@ spring:
     config:
       username: ${CONFIG_SERVER_USERNAME:admin}  # Config Server Basic Auth
       password: ${CONFIG_SERVER_PASSWORD:admin}
-
-  jpa:
-    hibernate:
-      ddl-auto: validate  # Flyway가 스키마 관리하므로 validate 고정
-    open-in-view: false # Open Session In View 패턴 비활성화 - DB 커넥션 점유 이슈 있음
-
-
-  flyway:
-    enabled: true # Flyway 마이그레이션 활성화
-    locations: classpath:db/migration
-    baseline-on-migrate: true # 기존 DB에 Flyway 첫 적용 시 기준선 자동 생성
-
-  jackson:
-    time-zone: Asia/Seoul
-    serialization:
-      write-dates-as-timestamps: false  # ISO-8601 문자열로 직렬화
-
-eureka:
-  client:
-    register-with-eureka: true
-    fetch-registry: true
-    tls:
-      enabled: false
-  instance:
-    prefer-ip-address: true
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info
-
-keycloak:
-  realm: first-ticket # Keycloak Realm
-  client-id: ${KEYCLOAK_CLIENT_ID:user-client} # 클라이언트 ID


### PR DESCRIPTION
## 🌱 설명
- 로그아웃 (/api/v1/auth/logout) 구현
- 토큰 재발급 (/api/v1/auth/token/refresh) 구현

## 📌 관련 이슈
- close #9 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명

### 로컬 테스트 환경

### 1. docker로 infra 레포 전부 실행

<img width="1367" height="307" alt="image" src="https://github.com/user-attachments/assets/eb4dcb29-8147-445c-96f2-ea8296b89e5b" />

### 2. IntelliJ 로컬 실행

```
config-server > eureka-server > gateway-server > user-service
```
- config-server는 루트에 .env 세팅후 실행
- user-service는 application-local.yaml로 세팅
- KEYCLOAK_CLIENT_SECRET 설정 방법 
- 1. infra 도커 실행 후 keycloak 어드민 접속 (localhost:8180) (admin/admin)
- 2. Clients > user-client 들어가기
- 3. Credentials > Client Secret 복사해서 .env에 세팅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리프레시 토큰을 통한 토큰 재발급(토큰 갱신) API 추가 — 클라이언트는 리프레시 토큰으로 새 토큰을 받을 수 있습니다.
  * 로그아웃 엔드포인트 추가 — 요청 시 저장된 세션/리프레시 토큰이 삭제되어 안전하게 로그아웃됩니다.
  * 토큰 재발급 검증 및 회전 처리로 보안 강화.

* **문서**
  * 예시 환경파일에 Keycloak 클라이언트 시크릿 설정 항목 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->