### PR TITLE
[feat][user-service] HOST 신청 관리 API 구현

### DIFF
--- a/src/main/java/com/firstticket/userservice/application/HostRequestAction.java
+++ b/src/main/java/com/firstticket/userservice/application/HostRequestAction.java
@@ -1,0 +1,16 @@
+package com.firstticket.userservice.application;
+
+/**
+ * HOST 신청 처리 액션
+ * PATCH /api/v1/admin/host-requests/{requestId} 요청 바디에서 사용
+ * Jackson이 "APPROVE" / "REJECT" 문자열을 자동으로 역직렬화
+ *
+ * domain이 아닌 application 위치 이유
+ * - HTTP 요청 바디 (APPROVE/REJECT)를 Application 계층 파라미터로 변환
+ * - domain의 상태 전이 규칙은 HostRequestStatus.validateNext()가 담당
+ * - HostRequestAction을 domain에 두면 Jackson 직렬화 Presentation 관심사가 domain 레이어에 침투
+ */
+public enum HostRequestAction {
+    APPROVE,
+    REJECT
+}

--- a/src/main/java/com/firstticket/userservice/application/HostRequestCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/HostRequestCommandService.java
@@ -13,9 +13,12 @@ import com.firstticket.userservice.domain.service.KeycloakAuthService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -68,11 +71,17 @@ public class HostRequestCommandService {
 
         // 4. HostRequest 생성 - userId는 DB PK (host_requests.user_id FK)
         HostRequest hostRequest = HostRequest.create(user.getId());
-        HostRequest saved = hostRequestRepository.save(hostRequest);
 
-        log.info("[hostRequest] HOST 신청 완료 - userId: {}, requestId: {}",
-            mask(user.getId()), mask(saved.getId()));
-        return HostRequestResult.from(saved);
+        try {
+            HostRequest saved = hostRequestRepository.save(hostRequest);
+            log.info("[hostRequest] HOST 신청 완료 - userId: {}, requestId: {}",
+                mask(user.getId()), mask(saved.getId()));
+            return HostRequestResult.from(saved);
+        } catch (DataIntegrityViolationException e) {
+            // unique constraint 위반 = 동시 요청으로 PENDING이 이미 생성된 경우
+            log.warn("[hostRequest] 동시 요청으로 인한 PENDING 충돌 - userId: {}", mask(user.getId()));
+            throw new UserException(UserErrorCode.HOST_REQUEST_ALREADY_PENDING);
+        }
     }
 
     /**
@@ -91,6 +100,8 @@ public class HostRequestCommandService {
      */
     @Transactional
     public HostRequestResult approveOrReject(UUID requestId, HostRequestAction action, UUID adminId) {
+
+        Objects.requireNonNull(action, "action 값은 null일 수 없습니다.");
 
         // 1. HostRequest 조회
         HostRequest hostRequest = hostRequestRepository.findById(requestId)

--- a/src/main/java/com/firstticket/userservice/application/HostRequestCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/HostRequestCommandService.java
@@ -1,0 +1,145 @@
+package com.firstticket.userservice.application;
+
+import com.firstticket.userservice.application.dto.result.HostRequestResult;
+import com.firstticket.userservice.domain.HostRequest;
+import com.firstticket.userservice.domain.HostRequestRepository;
+import com.firstticket.userservice.domain.HostRequestStatus;
+import com.firstticket.userservice.domain.User;
+import com.firstticket.userservice.domain.UserRepository;
+import com.firstticket.userservice.domain.UserRole;
+import com.firstticket.userservice.domain.exception.UserErrorCode;
+import com.firstticket.userservice.domain.exception.UserException;
+import com.firstticket.userservice.domain.service.KeycloakAuthService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 설계 결정 사항
+ * - HostRequest는 User와 별개의 Aggregate이므로 별도의 Command Service로 처리
+ * - HOST 신청에 대해 APPROVE 처리 시 User.changeRole(HOST) + Keycloak 동기화를 해당 서비스가 조율
+ * - DDD - Aggregate 간 협력은 Application 계층이 담당
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HostRequestCommandService {
+
+    private final HostRequestRepository hostRequestRepository;
+    private final UserRepository userRepository;
+    private final KeycloakAuthService keycloakAuthService;
+
+    /**
+     * HOST 신청 (CUSTOMER)
+     *
+     * 처리 흐름
+     * 1. keycloakId로 신청자 User 조회 (X-User-Id 헤더 = Keycloak sub claim = keycloakId)
+     * 2. CUSTOMER 역할 검증 (HOST/ADMIN은 신청 불가)
+     * 3. PENDING 중복 신청 확인 (DB PK 기준)
+     * 4. HostRequest 생성 (userId = user.getId() - DB PK)
+     * 5. DB 저장 후 HostRequestResult 반환
+     */
+    @Transactional
+    public HostRequestResult request(UUID keycloakId) {
+
+        // 1. Keycloak ID로 User 조회 - X-User-Id는 JWT sub(= keycloakId)이므로 findByKeycloakId() 사용
+        User user = userRepository.findByKeycloakId(keycloakId.toString())
+            .orElseThrow(() -> {
+                log.warn("[hostRequest] 존재하지 않는 사용자의 HOST 신청 시도 - keycloakId: {}", mask(keycloakId));
+                return new UserException(UserErrorCode.USER_NOT_FOUND);
+            });
+
+        // 2. 역할 검증 - CUSTOMER만 HOST 신청 가능
+        if (user.getRole() != UserRole.CUSTOMER) {
+            log.warn("[hostRequest] 비CUSTOMER 역할의 HOST 신청 시도 - userId: {}, role: {}",
+                mask(user.getId()), user.getRole());
+            throw new UserException(UserErrorCode.HOST_REQUEST_ONLY_FOR_CUSTOMER);
+        }
+
+        // 3. PENDING 중복 신청 확인 - DB PK(user.getId())로 확인
+        if (hostRequestRepository.existsByUserIdAndStatus(user.getId(), HostRequestStatus.PENDING)) {
+            log.warn("[hostRequest] 중복 PENDING 신청 시도 - userId: {}", mask(user.getId()));
+            throw new UserException(UserErrorCode.HOST_REQUEST_ALREADY_PENDING);
+        }
+
+        // 4. HostRequest 생성 - userId는 DB PK (host_requests.user_id FK)
+        HostRequest hostRequest = HostRequest.create(user.getId());
+        HostRequest saved = hostRequestRepository.save(hostRequest);
+
+        log.info("[hostRequest] HOST 신청 완료 - userId: {}, requestId: {}",
+            mask(user.getId()), mask(saved.getId()));
+        return HostRequestResult.from(saved);
+    }
+
+    /**
+     * HOST 신청 승인/거절 (ADMIN)
+     *
+     * 처리 흐름 - APPROVE
+     * 1. HostRequest 조회
+     * 2. HostRequest.approve() -> PENDING -> APPROVED status 전이
+     * 3. User 조회 -> changeRole(HOST)
+     * 4. Keycloak role 동기화 (CUSTOMER → HOST)
+     *
+     * 처리 흐름 - REJECT
+     * 1. HostRequest 조회
+     * 2. HostRequest.reject() → PENDING → REJECTED 전이 (불가 시 예외)
+     *    User role은 변경하지 않습니다.
+     */
+    @Transactional
+    public HostRequestResult approveOrReject(UUID requestId, HostRequestAction action, UUID adminId) {
+
+        // 1. HostRequest 조회
+        HostRequest hostRequest = hostRequestRepository.findById(requestId)
+            .orElseThrow(() -> {
+                log.warn("[approveOrReject] 존재하지 않는 HOST 신청 - requestId: {}", mask(requestId));
+                return new UserException(UserErrorCode.HOST_REQUEST_NOT_FOUND);
+            });
+
+        if (action == HostRequestAction.APPROVE) {
+            // 2. 상태 전이 - PENDING → APPROVED
+            hostRequest.approve();
+
+            // 3. 신청자 User 조회
+            User user = userRepository.findById(hostRequest.getUserId())
+                .orElseThrow(() -> {
+                    // 데이터 정합성 오류 — 운영 추적을 위해 userId 원문 기록
+                    log.error("[approveOrReject] 신청자 User 없음 - 데이터 정합성 오류. userId: {}",
+                        hostRequest.getUserId());
+                    return new UserException(UserErrorCode.USER_NOT_FOUND);
+                });
+
+            // 4. DB role 변경 (CUSTOMER → HOST) - User.changeRole() 내부에서 DELETED 불변식 검증
+            UserRole oldRole = user.getRole();
+            user.changeRole(UserRole.HOST);
+
+            // 5. Keycloak role 동기화
+            // Known limitation : DB 커밋 실패 시 Keycloak만 변경된 불일치 가능 -> 추후 Outbox 패턴 적용 예정
+            keycloakAuthService.changeUserRole(user.getKeycloakId(), oldRole.name(), UserRole.HOST.name());
+
+            log.info("[approveOrReject] HOST 승인 완료 - requestId: {}, userId: {}, adminId: {}",
+                mask(requestId), mask(user.getId()), mask(adminId));
+
+        } else {
+            // REJECT - HostRequest 상태만 변경, User role 불변
+            hostRequest.reject();
+            log.info("[approveOrReject] HOST 거절 완료 - requestId: {}, adminId: {}",
+                mask(requestId), mask(adminId));
+        }
+
+        return HostRequestResult.from(hostRequest);
+    }
+
+    /**
+     * 운영 로그에서 UUID 식별자 부분 마스킹합니다.
+     * 예) 637a8e5c-8f7c-41ff-b4bb-849755817a5b
+     *  → 637a8e5c-****-****-****-************
+     */
+    private static String mask(UUID uuid) {
+        if (uuid == null) return "null";
+        return uuid.toString().substring(0, 8) + "-****-****-****-************";
+    }
+}

--- a/src/main/java/com/firstticket/userservice/application/HostRequestCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/HostRequestCommandService.java
@@ -49,6 +49,9 @@ public class HostRequestCommandService {
     @Transactional
     public HostRequestResult request(UUID keycloakId) {
 
+        // keycloakId null 방어
+        Objects.requireNonNull(keycloakId, "keycloakId 값은 null일 수 없습니다.");
+
         // 1. Keycloak ID로 User 조회 - X-User-Id는 JWT sub(= keycloakId)이므로 findByKeycloakId() 사용
         User user = userRepository.findByKeycloakId(keycloakId.toString())
             .orElseThrow(() -> {
@@ -78,9 +81,13 @@ public class HostRequestCommandService {
                 mask(user.getId()), mask(saved.getId()));
             return HostRequestResult.from(saved);
         } catch (DataIntegrityViolationException e) {
-            // unique constraint 위반 = 동시 요청으로 PENDING이 이미 생성된 경우
-            log.warn("[hostRequest] 동시 요청으로 인한 PENDING 충돌 - userId: {}", mask(user.getId()));
-            throw new UserException(UserErrorCode.HOST_REQUEST_ALREADY_PENDING);
+            // 지적 2: uq_host_requests_user_pending 충돌인 경우만 409로 변환
+            // FK 위반(user_id), CHECK 위반(status) 등 다른 제약 위반은 그대로 전파
+            if (isPendingDuplicateViolation(e)) {
+                log.warn("[hostRequest] 동시 요청으로 인한 PENDING 충돌 - userId: {}", mask(user.getId()));
+                throw new UserException(UserErrorCode.HOST_REQUEST_ALREADY_PENDING);
+            }
+            throw e;
         }
     }
 
@@ -119,7 +126,7 @@ public class HostRequestCommandService {
                 .orElseThrow(() -> {
                     // 데이터 정합성 오류 — 운영 추적을 위해 userId 원문 기록
                     log.error("[approveOrReject] 신청자 User 없음 - 데이터 정합성 오류. userId: {}",
-                        hostRequest.getUserId());
+                        mask(hostRequest.getUserId()));
                     return new UserException(UserErrorCode.USER_NOT_FOUND);
                 });
 
@@ -152,5 +159,16 @@ public class HostRequestCommandService {
     private static String mask(UUID uuid) {
         if (uuid == null) return "null";
         return uuid.toString().substring(0, 8) + "-****-****-****-************";
+    }
+
+    /**
+     * DataIntegrityViolationException이 PENDING 중복 unique 충돌인지 판별합니다.
+     * DB 인덱스명(uq_host_requests_user_pending)이 예외 메시지에 포함되어 있으면 해당 충돌로 간주합니다.
+     */
+    private static boolean isPendingDuplicateViolation(DataIntegrityViolationException e) {
+        Throwable cause = e.getMostSpecificCause();
+        return cause != null
+            && cause.getMessage() != null
+            && cause.getMessage().contains("uq_host_requests_user_pending");
     }
 }

--- a/src/main/java/com/firstticket/userservice/application/HostRequestQueryService.java
+++ b/src/main/java/com/firstticket/userservice/application/HostRequestQueryService.java
@@ -1,18 +1,16 @@
 package com.firstticket.userservice.application;
 
-import com.firstticket.userservice.application.dto.result.HostRequestResult;
-import com.firstticket.userservice.domain.HostRequestRepository;
-import com.firstticket.userservice.domain.HostRequestStatus;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import com.firstticket.userservice.application.dto.result.HostRequestResult;
+import com.firstticket.userservice.domain.HostRequestStatus;
+import com.firstticket.userservice.domain.query.HostRequestQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -20,14 +18,14 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class HostRequestQueryService {
 
-    private final HostRequestRepository hostRequestRepository;
+    private final HostRequestQueryRepository hostRequestQueryRepository;
 
     /**
      * PENDING 상태의 HOST 신청 목록 페이지 조회
      * AdminController에서 Pageable(page, size, sort)을 전달
      */
     public Page<HostRequestResult> getHostRequests(Pageable pageable) {
-        return hostRequestRepository.findAllByStatus(HostRequestStatus.PENDING, pageable)
+        return hostRequestQueryRepository.findAllByStatus(HostRequestStatus.PENDING, pageable)
             .map(HostRequestResult::from);
     }
 }

--- a/src/main/java/com/firstticket/userservice/application/HostRequestQueryService.java
+++ b/src/main/java/com/firstticket/userservice/application/HostRequestQueryService.java
@@ -1,0 +1,33 @@
+package com.firstticket.userservice.application;
+
+import com.firstticket.userservice.application.dto.result.HostRequestResult;
+import com.firstticket.userservice.domain.HostRequestRepository;
+import com.firstticket.userservice.domain.HostRequestStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HostRequestQueryService {
+
+    private final HostRequestRepository hostRequestRepository;
+
+    /**
+     * PENDING 상태의 HOST 신청 목록 페이지 조회
+     * AdminController에서 Pageable(page, size, sort)을 전달
+     */
+    public Page<HostRequestResult> getHostRequests(Pageable pageable) {
+        return hostRequestRepository.findAllByStatus(HostRequestStatus.PENDING, pageable)
+            .map(HostRequestResult::from);
+    }
+}

--- a/src/main/java/com/firstticket/userservice/application/dto/result/HostRequestResult.java
+++ b/src/main/java/com/firstticket/userservice/application/dto/result/HostRequestResult.java
@@ -1,0 +1,23 @@
+package com.firstticket.userservice.application.dto.result;
+
+import com.firstticket.userservice.domain.HostRequest;
+import com.firstticket.userservice.domain.HostRequestStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record HostRequestResult(
+    UUID id,
+    UUID userId,
+    HostRequestStatus status,
+    LocalDateTime createdAt  // BaseEntity.createdAt
+) {
+    public static HostRequestResult from(HostRequest hostRequest) {
+        return new HostRequestResult(
+            hostRequest.getId(),
+            hostRequest.getUserId(),
+            hostRequest.getStatus(),
+            hostRequest.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/firstticket/userservice/domain/HostRequestRepository.java
+++ b/src/main/java/com/firstticket/userservice/domain/HostRequestRepository.java
@@ -1,11 +1,7 @@
 package com.firstticket.userservice.domain;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 /**
  * HostRequest Aggregate 명령(Command) 전용 Repository 인터페이스
@@ -33,6 +29,4 @@ public interface HostRequestRepository {
      *   existsByUserIdAndStatus(userId, HostRequestStatus.PENDING)
      */
     boolean existsByUserIdAndStatus(UUID userId, HostRequestStatus status);
-
-    Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable);
 }

--- a/src/main/java/com/firstticket/userservice/domain/HostRequestRepository.java
+++ b/src/main/java/com/firstticket/userservice/domain/HostRequestRepository.java
@@ -1,7 +1,11 @@
 package com.firstticket.userservice.domain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * HostRequest Aggregate 명령(Command) 전용 Repository 인터페이스
@@ -29,4 +33,6 @@ public interface HostRequestRepository {
      *   existsByUserIdAndStatus(userId, HostRequestStatus.PENDING)
      */
     boolean existsByUserIdAndStatus(UUID userId, HostRequestStatus status);
+
+    Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable);
 }

--- a/src/main/java/com/firstticket/userservice/domain/User.java
+++ b/src/main/java/com/firstticket/userservice/domain/User.java
@@ -137,7 +137,7 @@ public class User extends BaseUserEntity {
      */
     public void changeRole(UserRole newRole) {
         if (this.status == UserStatus.DELETED) {
-            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
         }
         this.role = newRole;
     }

--- a/src/main/java/com/firstticket/userservice/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/firstticket/userservice/domain/exception/UserErrorCode.java
@@ -24,6 +24,7 @@ public enum UserErrorCode implements ErrorCode {
     HOST_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "HOST 신청 요청을 찾을 수 없습니다."),
     INVALID_HOST_REQUEST_STATUS(HttpStatus.BAD_REQUEST, "허용되지 않은 HOST 신청 상태 전이입니다."),
     HOST_REQUEST_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 검토 중인 HOST 신청이 존재합니다."),
+    HOST_REQUEST_ONLY_FOR_CUSTOMER(HttpStatus.FORBIDDEN, "CUSTOMER 계정만 HOST 신청이 가능합니다."),
 
     // Token
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),

--- a/src/main/java/com/firstticket/userservice/domain/query/HostRequestQueryRepository.java
+++ b/src/main/java/com/firstticket/userservice/domain/query/HostRequestQueryRepository.java
@@ -1,0 +1,12 @@
+package com.firstticket.userservice.domain.query;
+
+import com.firstticket.userservice.domain.HostRequest;
+import com.firstticket.userservice.domain.HostRequestStatus;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface HostRequestQueryRepository {
+
+    Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable);
+}

--- a/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestJpaRepository.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestJpaRepository.java
@@ -1,8 +1,11 @@
 package com.firstticket.userservice.infrastructure.persistence;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.firstticket.userservice.domain.HostRequest;
@@ -21,8 +24,11 @@ public interface HostRequestJpaRepository extends JpaRepository<HostRequest, UUI
     Optional<HostRequest> findByUserIdAndStatus(UUID userId, HostRequestStatus status);
 
     /**
-     * 특정 사용자의 특정 상태 신청 존재 여부 - EXISTS 쿼리로 성능 최적화.
+     * 특정 사용자의 특정 상태 신청 존재 여부
      * 중복 PENDING 신청 방지에 사용
      */
     boolean existsByUserIdAndStatus(UUID userId, HostRequestStatus status);
+
+    // status 조건 + 페이지네이션 조회
+    Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable);
 }

--- a/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestQueryRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.firstticket.userservice.infrastructure.persistence;
+
+import com.firstticket.userservice.domain.HostRequest;
+import com.firstticket.userservice.domain.HostRequestStatus;
+import com.firstticket.userservice.domain.query.HostRequestQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HostRequestQueryRepositoryImpl implements HostRequestQueryRepository {
+
+    private final HostRequestJpaRepository hostRequestJpaRepository;
+
+    @Override
+    public Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable) {
+        return hostRequestJpaRepository.findAllByStatus(status, pageable);
+    }
+}

--- a/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestRepositoryImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestRepositoryImpl.java
@@ -1,17 +1,15 @@
 package com.firstticket.userservice.infrastructure.persistence;
 
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
 import com.firstticket.userservice.domain.HostRequest;
 import com.firstticket.userservice.domain.HostRequestRepository;
 import com.firstticket.userservice.domain.HostRequestStatus;
+
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * HostRequestRepository 도메인 인터페이스의 JPA 구현체
@@ -42,11 +40,5 @@ public class HostRequestRepositoryImpl implements HostRequestRepository {
     @Override
     public boolean existsByUserIdAndStatus(UUID userId, HostRequestStatus status) {
         return hostRequestJpaRepository.existsByUserIdAndStatus(userId, status);
-    }
-
-    @Override
-    public Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable) {
-        // Spring Data가 COUNT 쿼리를 자동 생성해 Page 메타데이터(totalElements 등)를 채웁니다
-        return hostRequestJpaRepository.findAllByStatus(status, pageable);
     }
 }

--- a/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestRepositoryImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/persistence/HostRequestRepositoryImpl.java
@@ -4,8 +4,12 @@ import com.firstticket.userservice.domain.HostRequest;
 import com.firstticket.userservice.domain.HostRequestRepository;
 import com.firstticket.userservice.domain.HostRequestStatus;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,5 +42,11 @@ public class HostRequestRepositoryImpl implements HostRequestRepository {
     @Override
     public boolean existsByUserIdAndStatus(UUID userId, HostRequestStatus status) {
         return hostRequestJpaRepository.existsByUserIdAndStatus(userId, status);
+    }
+
+    @Override
+    public Page<HostRequest> findAllByStatus(HostRequestStatus status, Pageable pageable) {
+        // Spring Data가 COUNT 쿼리를 자동 생성해 Page 메타데이터(totalElements 등)를 채웁니다
+        return hostRequestJpaRepository.findAllByStatus(status, pageable);
     }
 }

--- a/src/main/java/com/firstticket/userservice/presentation/AdminController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/AdminController.java
@@ -5,13 +5,18 @@ import com.firstticket.common.response.ApiResponse;
 import com.firstticket.common.response.CommonErrorCode;
 import com.firstticket.common.web.AuthContext;
 import com.firstticket.common.web.UserRole;
+import com.firstticket.userservice.application.HostRequestCommandService;
+import com.firstticket.userservice.application.HostRequestQueryService;
 import com.firstticket.userservice.application.UserCommandService;
 import com.firstticket.userservice.application.UserQueryService;
+import com.firstticket.userservice.application.dto.result.HostRequestResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
 import com.firstticket.userservice.domain.query.UserSummaryData;
+import com.firstticket.userservice.presentation.dto.request.ApproveRejectRequest;
 import com.firstticket.userservice.presentation.dto.request.ChangeRoleRequest;
 import com.firstticket.userservice.presentation.dto.request.UserSearchRequest;
 import com.firstticket.userservice.presentation.dto.response.AdminUserResponse;
+import com.firstticket.userservice.presentation.dto.response.HostRequestResponse;
 import com.firstticket.userservice.presentation.dto.response.UserResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +26,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -42,6 +48,8 @@ public class AdminController {
 
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
+    private final HostRequestCommandService hostRequestCommandService;
+    private final HostRequestQueryService hostRequestQueryService;
 
     /**
      * 사용자 목록 조회 (동적 검색 + 페이지네이션)
@@ -160,6 +168,63 @@ public class AdminController {
         return ApiResponse.success(
             UserSuccessCode.ROLE_CHANGED,
             UserResponse.from(result)
+        );
+    }
+
+    /**
+     * PENDING HOST 신청 목록 조회 (페이지네이션)
+     * GET /api/v1/admin/host-requests?page=0&size=10&sort=createdAt,desc
+     *
+     * @param pageable 페이지 정보
+     * @return 200 OK + Page<HostRequestResponse> (PENDING 상태만)
+     *
+     * 오류 응답:
+     *   401 Unauthorized - X-User-Role 헤더 누락
+     *   403 Forbidden    - ADMIN 이외의 역할
+     */
+    @GetMapping("/api/v1/admin/host-requests")
+    public ResponseEntity<ApiResponse<Page<HostRequestResponse>>> getHostRequests(Pageable pageable) {
+        AuthContext.requireRole(UserRole.ADMIN);
+
+        // Page<HostRequestResult> → Page<HostRequestResponse> 변환
+        Page<HostRequestResponse> responses = hostRequestQueryService.getHostRequests(pageable)
+            .map(HostRequestResponse::from);
+
+        return ApiResponse.success(UserSuccessCode.HOST_REQUEST_LIST_FOUND, responses);
+    }
+
+    /**
+     * HOST 신청 승인/거절
+     * PATCH /api/v1/admin/host-requests/{requestId}
+     * Body: { "action": "APPROVE" | "REJECT" }
+     *
+     * @param requestId 처리할 HOST 신청 UUID
+     * @param request   액션 (APPROVE / REJECT)
+     * @return 200 OK + HostRequestResponse (처리 결과)
+     *
+     * 오류 응답:
+     *   400 Bad Request  - action 필드 누락
+     *   401 Unauthorized - X-User-Role 헤더 누락
+     *   403 Forbidden    - ADMIN 이외의 역할
+     *   404 Not Found    - 존재하지 않는 requestId
+     *   409 Conflict     - 이미 처리된 신청
+     */
+    @PatchMapping("/api/v1/admin/host-requests/{requestId}")
+    public ResponseEntity<ApiResponse<HostRequestResponse>> approveOrReject(
+        @PathVariable UUID requestId,
+        @RequestBody @Valid ApproveRejectRequest request
+    ) {
+        // 1. 권한 검증 -> 2. adminId 추출
+        AuthContext.requireRole(UserRole.ADMIN);
+        UUID adminId = AuthContext.getUserId();
+
+        HostRequestResult result = hostRequestCommandService.approveOrReject(
+            requestId, request.action(), adminId
+        );
+
+        return ApiResponse.success(
+            UserSuccessCode.HOST_REQUEST_PROCESSED,
+            HostRequestResponse.from(result)
         );
     }
 }

--- a/src/main/java/com/firstticket/userservice/presentation/UserController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserController.java
@@ -4,13 +4,17 @@ import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.firstticket.common.response.ApiResponse;
 import com.firstticket.common.web.AuthContext;
+import com.firstticket.userservice.application.HostRequestCommandService;
 import com.firstticket.userservice.application.UserQueryService;
+import com.firstticket.userservice.application.dto.result.HostRequestResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
+import com.firstticket.userservice.presentation.dto.response.HostRequestResponse;
 import com.firstticket.userservice.presentation.dto.response.UserResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -34,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final HostRequestCommandService hostRequestCommandService;
 
     /**
      * 내 정보 조회 API
@@ -59,6 +64,31 @@ public class UserController {
         return ApiResponse.success(
             UserSuccessCode.USER_FOUND,
             UserResponse.from(result)
+        );
+    }
+
+    /**
+     * HOST 신청 API
+     * POST /api/v1/users/me/host-requests
+     *
+     * Gateway의 X-User-Id 헤더로 신청자 UUID를 식별합니다.
+     * 요청 바디 없음
+     *
+     * @return 201 Created + HostRequestResponse (id, userId, status: PENDING, createdAt)
+     *
+     * 오류 응답:
+     *   401 Unauthorized - X-User-Id 헤더 누락
+     *   409 Conflict     - 이미 PENDING 상태의 신청이 존재
+     */
+    @PostMapping("/me/host-requests")
+    public ResponseEntity<ApiResponse<HostRequestResponse>> requestHost() {
+        UUID keycloakId = AuthContext.getUserId();
+
+        HostRequestResult result = hostRequestCommandService.request(keycloakId);
+
+        return ApiResponse.success(
+            UserSuccessCode.HOST_REQUEST_CREATED,
+            HostRequestResponse.from(result)
         );
     }
 }

--- a/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
@@ -22,7 +22,12 @@ public enum UserSuccessCode implements SuccessCode {
     //ADMIN CRUD
     USER_LIST_FOUND(HttpStatus.OK, "사용자 목록을 조회했습니다."), // 200
     USER_DELETED(HttpStatus.OK, "사용자 탈퇴 처리가 완료되었습니다."), // 200
-    ROLE_CHANGED(HttpStatus.OK, "사용자 역할이 변경되었습니다."); // 200
+    ROLE_CHANGED(HttpStatus.OK, "사용자 역할이 변경되었습니다."), // 200
+
+    //HOST Request
+    HOST_REQUEST_CREATED(HttpStatus.CREATED, "HOST 신청이 완료되었습니다."),     // 201
+    HOST_REQUEST_LIST_FOUND(HttpStatus.OK, "HOST 신청 목록을 조회했습니다."),     // 200
+    HOST_REQUEST_PROCESSED(HttpStatus.OK, "HOST 신청이 처리되었습니다.");         // 200
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/userservice/presentation/dto/request/ApproveRejectRequest.java
+++ b/src/main/java/com/firstticket/userservice/presentation/dto/request/ApproveRejectRequest.java
@@ -1,0 +1,16 @@
+package com.firstticket.userservice.presentation.dto.request;
+
+import com.firstticket.userservice.application.HostRequestAction;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * HOST 신청 승인/거절 요청 DTO
+ * PATCH /api/v1/admin/host-requests/{requestId}
+ * Body: { "action": "APPROVE" } or { "action": "REJECT" }
+ */
+public record ApproveRejectRequest(
+
+    // Jackson이 "APPROVE"/"REJECT" 문자열을 HostRequestAction enum으로 역직렬화
+    @NotNull(message = "action 값은 필수입니다.")
+    HostRequestAction action
+) {}

--- a/src/main/java/com/firstticket/userservice/presentation/dto/response/HostRequestResponse.java
+++ b/src/main/java/com/firstticket/userservice/presentation/dto/response/HostRequestResponse.java
@@ -1,0 +1,24 @@
+package com.firstticket.userservice.presentation.dto.response;
+
+import com.firstticket.userservice.application.dto.result.HostRequestResult;
+import com.firstticket.userservice.domain.HostRequestStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// HOST 신청 Presentation 응답 DTO
+public record HostRequestResponse(
+    UUID id,
+    UUID userId,
+    HostRequestStatus status,
+    LocalDateTime createdAt
+) {
+    public static HostRequestResponse from(HostRequestResult result) {
+        return new HostRequestResponse(
+            result.id(),
+            result.userId(),
+            result.status(),
+            result.createdAt()
+        );
+    }
+}


### PR DESCRIPTION
  ## 🌱 설명

  HOST 신청·관리 관련 API 3개를 구현합니다.

  - `POST /api/v1/users/me/host-requests` - CUSTOMER가 HOST 권한을 신청
  - `GET /api/v1/admin/host-requests` - ADMIN이 PENDING 신청 목록 조회 (페이지네이션)
  - `PATCH /api/v1/admin/host-requests/{requestId}` - ADMIN이 신청 승인 또는 거절


  ## 📌 관련 이슈

  close #15 


  ## 💻 커밋 유형

  - [x] feat     : 새로운 기능 추가


  ## 📝 체크리스트

  - [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
  - [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
  - [x] 관련 이슈와 연결했나요?
  - [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
  - [x] 제가 작성한 코드를 스스로 리뷰했습니다.
  - [x] 기존 테스트와 충돌하지 않음을 확인했나요?


  ## 📚 추가 설명

  ### 처리 흐름 — 승인(APPROVE)

  PATCH /api/v1/admin/host-requests/{requestId}  { "action": "APPROVE" }
  HostRequest.approve()          // PENDING → APPROVED (Enum 내부 전이 검증)
  User.changeRole(HOST)          // DB role 변경
  KeycloakAuthService.changeUserRole()  // Keycloak role 동기화

  ### 설계 결정 사항

  **PENDING 중복 방지 이중 방어**
  Application 계층의 `existsByUserIdAndStatus()` 단독으로는 동시 요청 Race Condition 방어가 불충분합니다. DB의 Partial
  Unique Index (`WHERE status = 'PENDING' AND deleted_at IS NULL`)를 함께 적용해 이중으로 방어합니다.

  **X-User-Id = Keycloak sub (DB PK 아님)**
  `AuthContext.getUserId()`는 JWT `sub` claim(= keycloakId)을 반환합니다. HOST 신청 시 User 조회는
  `findByKeycloakId()`를 사용하고, `HostRequest.userId`에는 DB PK(`user.getId()`)를 저장합니다.

  **DB–Keycloak 원자성 한계 (Known Limitation)**
  `@Transactional`은 DB 트랜잭션만 보장합니다. DB 커밋 성공 후 Keycloak 호출이 실패하는 케이스는 현재 미처리 상태입니다.
   MVP 이후 Outbox 패턴 적용을 예정합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자가 HOST 신청을 할 수 있습니다 (POST /users/me/host-requests).
  * 관리자가 대기 중인 HOST 신청 목록을 조회할 수 있습니다 (페이징 지원).
  * 관리자가 특정 HOST 신청을 승인하거나 거절할 수 있습니다.

* **Behavior / UX**
  * HOST 승인 시 고객 계정이 호스트로 전환됩니다.
  * CUSTOMER 계정만 HOST 신청이 가능하도록 제한 및 관련 오류/응답 메시지 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->