### PR TITLE
[feat][user-service] 내 정보 수정 / 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -343,14 +343,8 @@ public class UserCommandService {
                 return new UserException(UserErrorCode.USER_NOT_FOUND);
             });
 
-        // 2. DELETED 사용자 차단
-        if (user.getStatus() == UserStatus.DELETED) {
-            log.warn("[updateProfile] 탈퇴 사용자의 정보 수정 시도 - userId: {}", mask(user.getId()));
-            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
-        }
-
-        // 3. username 수정
-        user.changeUsername(command.username());
+        // 2. 유효성 체크 후 수정 (엔티티 비즈니스 메서드로 이관)
+        user.updateProfile(command.username());
 
         log.info("[updateProfile] 정보 수정 완료 - userId: {}", mask(user.getId()));
         return UserResult.from(user);
@@ -365,7 +359,7 @@ public class UserCommandService {
      * 4. Redis Refresh Token 즉시 삭제 (현재 세션 무효화)
      *
      */
-    //TODO:DB 커밋 성공 후 Keycloak 호출 실패 시 불일치 발생 가능 -> MVP 구현 후추후 Outbox 패턴 적용 예정
+    //TODO:DB 커밋 성공 후 Keycloak 호출 실패 시 불일치 발생 가능 -> MVP 구현 후 @TransactionalEventListener(AFTER_COMMIT) 또는 Outbox 패턴 적용 예정
     @Transactional
     public void withdraw(String keycloakId) {
         Objects.requireNonNull(keycloakId, "keycloakId는 null일 수 없습니다.");

--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -1,11 +1,13 @@
 package com.firstticket.userservice.application;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import com.firstticket.userservice.application.dto.command.LoginCommand;
 import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
 import com.firstticket.userservice.application.dto.command.SignupCommand;
+import com.firstticket.userservice.application.dto.command.UpdateProfileCommand;
 import com.firstticket.userservice.application.dto.result.TokenResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
 import com.firstticket.userservice.domain.Email;
@@ -96,8 +98,8 @@ public class UserCommandService {
         // 생성할 테스트 계정 명세
         List<SeedUserSpec> specs = List.of(
             new SeedUserSpec("customer@first-ticket.com", "Customer1234!", "테스트고객", UserRole.CUSTOMER),
-            new SeedUserSpec("host@first-ticket.com",     "Host1234!",     "테스트호스트", UserRole.HOST),
-            new SeedUserSpec("admin@first-ticket.com",    "Admin1234!",    "관리자",      UserRole.ADMIN)
+            new SeedUserSpec("host@first-ticket.com", "Host1234!", "테스트호스트", UserRole.HOST),
+            new SeedUserSpec("admin@first-ticket.com", "Admin1234!", "관리자", UserRole.ADMIN)
         );
 
         return specs.stream()
@@ -150,7 +152,8 @@ public class UserCommandService {
         String password,
         String username,
         UserRole role
-    ) {}
+    ) {
+    }
 
     // ==================================== 테스트 계정 관련 끝 =====================================
 
@@ -320,5 +323,84 @@ public class UserCommandService {
 
         log.info("[changeRole] 역할 변경 완료 - targetUserId: {}, {} → {}", targetUserId, oldRole, newRole);
         return UserResult.from(user);
+    }
+
+    /**
+     * 내 정보 수정 (본인)
+     * 처리 흐름
+     * 1. keycloakId로 사용자 조회
+     * 2. DELETED 상태 차단 (LOCKED는 수정 허용 - display name 변경은 ok)
+     * 3. username 변경 후 UserResult 반환 (Keycloak 동기화 불필요 - user DB의 display name만 변경)
+     */
+    @Transactional
+    public UserResult updateProfile(String keycloakId, UpdateProfileCommand command) {
+        Objects.requireNonNull(keycloakId, "keycloakId는 null일 수 없습니다.");
+
+        // 1. keycloakId로 사용자 조회
+        User user = userRepository.findByKeycloakId(keycloakId)
+            .orElseThrow(() -> {
+                log.warn("[updateProfile] 존재하지 않는 사용자 - keycloakId: {}", mask(keycloakId));
+                return new UserException(UserErrorCode.USER_NOT_FOUND);
+            });
+
+        // 2. DELETED 사용자 차단
+        if (user.getStatus() == UserStatus.DELETED) {
+            log.warn("[updateProfile] 탈퇴 사용자의 정보 수정 시도 - userId: {}", mask(user.getId()));
+            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
+        }
+
+        // 3. username 수정
+        user.changeUsername(command.username());
+
+        log.info("[updateProfile] 정보 수정 완료 - userId: {}", mask(user.getId()));
+        return UserResult.from(user);
+    }
+
+    /**
+     * 회원 탈퇴 (본인)
+     * 처리 흐름
+     * 1. keycloakId로 사용자 조회
+     * 2. DB Soft Delete (status=DELETED, deletedBy=본인 DB PK)
+     * 3. Keycloak 계정 비활성화 (로그인 차단)
+     * 4. Redis Refresh Token 즉시 삭제 (현재 세션 무효화)
+     *
+     */
+    //TODO:DB 커밋 성공 후 Keycloak 호출 실패 시 불일치 발생 가능 -> MVP 구현 후추후 Outbox 패턴 적용 예정
+    @Transactional
+    public void withdraw(String keycloakId) {
+        Objects.requireNonNull(keycloakId, "keycloakId는 null일 수 없습니다.");
+
+        // 1. keycloakId로 사용자 조회
+        User user = userRepository.findByKeycloakId(keycloakId)
+            .orElseThrow(() -> {
+                log.warn("[withdraw] 존재하지 않는 사용자 - keycloakId: {}", mask(keycloakId));
+                return new UserException(UserErrorCode.USER_NOT_FOUND);
+            });
+
+        // 2. DB Soft Delete - user.softDelete() 내부에서 DELETED 상태 이중 전이 방지
+        user.softDelete(user.getId());
+
+        // 3. Keycloak 계정 비활성화 - 이후 로그인 불가
+        // 실패 시 UserException 발생 -> @Transactional 롤백 -> DB softDelete 취소
+        keycloakAuthService.disableUser(user.getKeycloakId());
+
+        // 4. Redis Refresh Token 즉시 삭제 - 현재 세션 즉시 무효화
+        refreshTokenStore.delete(user.getId());
+
+        log.info("[withdraw] 회원탈퇴 완료 - userId: {}", mask(user.getId()));
+    }
+
+    //UUID 마스킹
+    private static String mask(UUID uuid) {
+        if (uuid == null)
+            return "null";
+        return uuid.toString().substring(0, 8) + "-****-****-****-************";
+    }
+
+    // mask(String) 오버로드 - keycloakId는 String으로 전달되는 케이스 대응
+    private static String mask(String id) {
+        if (id == null || id.length() < 8)
+            return "****";
+        return id.substring(0, 8) + "-****-****-****-************";
     }
 }

--- a/src/main/java/com/firstticket/userservice/application/dto/command/UpdateProfileCommand.java
+++ b/src/main/java/com/firstticket/userservice/application/dto/command/UpdateProfileCommand.java
@@ -1,0 +1,11 @@
+package com.firstticket.userservice.application.dto.command;
+
+/**
+ * 내 정보 수정 Application Command DTO
+ * 현재 수정 가능한 필드: username (display name)
+ * 추후 필드 추가시 확장
+ * 이메일·비밀번호 변경은 별도 API 로 분리
+ */
+public record UpdateProfileCommand(
+    String username
+) {}

--- a/src/main/java/com/firstticket/userservice/domain/User.java
+++ b/src/main/java/com/firstticket/userservice/domain/User.java
@@ -162,4 +162,17 @@ public class User extends BaseUserEntity {
         }
         this.createdBy = id;
     }
+
+    /**
+     * 사용자 정보 수정
+     *
+     * - DELETED 상태의 사용자는 수정 불가
+     * - 향후 수정 가능 필드가 늘어나면 UpdateProfileCommand 형태로 파라미터 확장 가능
+     */
+    public void updateProfile(String newUsername) {
+        if (this.status == UserStatus.DELETED) {
+            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
+        }
+        this.username = newUsername;
+    }
 }

--- a/src/main/java/com/firstticket/userservice/presentation/UserController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserController.java
@@ -3,20 +3,27 @@ package com.firstticket.userservice.presentation;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.firstticket.common.response.ApiResponse;
 import com.firstticket.common.web.AuthContext;
 import com.firstticket.userservice.application.HostRequestCommandService;
+import com.firstticket.userservice.application.UserCommandService;
 import com.firstticket.userservice.application.UserQueryService;
+import com.firstticket.userservice.application.dto.command.UpdateProfileCommand;
 import com.firstticket.userservice.application.dto.result.HostRequestResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
+import com.firstticket.userservice.presentation.dto.request.UpdateProfileRequest;
 import com.firstticket.userservice.presentation.dto.response.HostRequestResponse;
 import com.firstticket.userservice.presentation.dto.response.UserResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
     private final HostRequestCommandService hostRequestCommandService;
 
     /**
@@ -55,16 +63,56 @@ public class UserController {
      *   404 Not Found    — 사용자가 존재하지 않거나 DELETED 상태
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo() {
+        UUID keycloakId = AuthContext.getUserId();
+        UserResult result = userQueryService.getMyInfo(keycloakId);
+        return ApiResponse.success(UserSuccessCode.USER_FOUND, UserResponse.from(result));
+    }
+
+    /**
+     * 내 정보 수정
+     * PATCH /api/v1/users/me
+     * Body: { "username": "새이름" }
+     *
+     * @return 200 OK + UserResponse (수정된 사용자 정보)
+     *
+     * 오류 응답:
+     *   400 Bad Request  - username 누락 또는 50자 초과
+     *   401 Unauthorized - X-User-Id 헤더 누락
+     *   404 Not Found    - 사용자 없음
+     *   410 Gone         - 이미 탈퇴된 사용자
+     */
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> updateProfile(
+        @RequestBody @Valid UpdateProfileRequest request
     ) {
-        UUID userId = AuthContext.getUserId();
-
-        UserResult result = userQueryService.getMyInfo(userId);
-
-        return ApiResponse.success(
-            UserSuccessCode.USER_FOUND,
-            UserResponse.from(result)
+        UUID keycloakId = AuthContext.getUserId();
+        UserResult result = userCommandService.updateProfile(
+            keycloakId.toString(),
+            new UpdateProfileCommand(request.username())
         );
+
+        return ApiResponse.success(UserSuccessCode.PROFILE_UPDATED, UserResponse.from(result));
+    }
+
+    /**
+     * 회원 탈퇴 (본인)
+     * DELETE /api/v1/users/me
+     *
+     * 처리 결과: DB Soft Delete + Keycloak 비활성화 + Redis 세션 즉시 무효화
+     *
+     * @return 200 OK (탈퇴 완료 메시지, data 없음)
+     *
+     * 오류 응답:
+     *   401 Unauthorized - X-User-Id 헤더 누락
+     *   404 Not Found    - 사용자 없음
+     *   410 Gone         - 이미 탈퇴된 사용자
+     */
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> withdraw() {
+        UUID keycloakId = AuthContext.getUserId();
+        userCommandService.withdraw(keycloakId.toString());
+        return ApiResponse.success(UserSuccessCode.WITHDRAW_SUCCESS);
     }
 
     /**
@@ -83,9 +131,7 @@ public class UserController {
     @PostMapping("/me/host-requests")
     public ResponseEntity<ApiResponse<HostRequestResponse>> requestHost() {
         UUID keycloakId = AuthContext.getUserId();
-
         HostRequestResult result = hostRequestCommandService.request(keycloakId);
-
         return ApiResponse.success(
             UserSuccessCode.HOST_REQUEST_CREATED,
             HostRequestResponse.from(result)

--- a/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
@@ -27,7 +27,11 @@ public enum UserSuccessCode implements SuccessCode {
     //HOST Request
     HOST_REQUEST_CREATED(HttpStatus.CREATED, "HOST 신청이 완료되었습니다."),     // 201
     HOST_REQUEST_LIST_FOUND(HttpStatus.OK, "HOST 신청 목록을 조회했습니다."),     // 200
-    HOST_REQUEST_PROCESSED(HttpStatus.OK, "HOST 신청이 처리되었습니다.");         // 200
+    HOST_REQUEST_PROCESSED(HttpStatus.OK, "HOST 신청이 처리되었습니다."),         // 200
+
+    // 내 정보 수정 / 회원탈퇴
+    PROFILE_UPDATED(HttpStatus.OK, "회원 정보가 수정되었습니다."),       // 200
+    WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴가 완료되었습니다.");      // 200
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/userservice/presentation/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/firstticket/userservice/presentation/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,13 @@
+package com.firstticket.userservice.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// PATCH /api/v1/users/me
+public record UpdateProfileRequest(
+
+    @NotBlank(message = "사용자 이름은 필수입니다.")
+    @Size(max = 50, message = "사용자 이름은 50자 이하여야 합니다.")
+    String username
+
+) {}


### PR DESCRIPTION


## 🌱 설명
- PATCH /api/v1/users/me: username 변경 (DELETED 상태 차단, LOCKED 허용)
- DELETE /api/v1/users/me: Soft Delete + Keycloak 비활성화 + Redis 세션 무효화
- UpdateProfileCommand / UpdateProfileRequest DTO 추가
- UserSuccessCode: PROFILE_UPDATED, WITHDRAW_SUCCESS 추가


## 📌 관련 이슈

- close #17 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
  ### 내 정보 수정 (`updateProfile`)
  - 수정 가능 필드: `username`만 허용. 이메일·비밀번호 변경은 별도 API로 분리 예정
  - `DELETED` 상태 → 410 Gone 차단. `LOCKED` 상태는 허용 (display name 변경은 무해함)
  - Keycloak 동기화 불필요 - Keycloak의 `preferred_username`과 서비스 DB의 `username`은 독립적으로 관리

  ### 회원 탈퇴 (`withdraw`)
  - DB Soft Delete (`status = DELETED`, `deleted_at` 기록)
  - Keycloak 계정 비활성화 (`enabled = false`) - 소셜 재가입 시 데이터 연속성 보장 목적으로 완전 삭제 대신 비활성화 선택
  - Redis Refresh Token 즉시 삭제 - 기존 토큰으로의 세션 재활성화 방지
  -DB-Keycloak 간 원자성 미보장 (Outbox 패턴은 MVP 이후 적용 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 수정: 인증 사용자가 자신의 사용자명(최대 50자)을 수정할 수 있습니다.
  * 계정 탈퇴: 사용자가 계정을 탈퇴할 수 있으며, 탈퇴 즉시 현재 세션이 무효화되어 로그아웃됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->