### PR TITLE
[chore][user-service] REST Docs 빌드 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.first-ticket'
@@ -53,6 +54,7 @@ repositories {
 
 ext {
 	set('springCloudVersion', "2025.0.2")
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencyManagement {
@@ -61,8 +63,12 @@ dependencyManagement {
 	}
 }
 
-// Querydsl Q클래스 생성 경로 (build 디렉토리 내부로 지정해 clean 시 자동 삭제)
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// Asciidoctor 확장 의존성 전용 설정 (spring-restdocs-asciidoctor)
+configurations {
+    asciidoctorExt
+}
 
 configurations.all {
 	resolutionStrategy {
@@ -125,6 +131,12 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testRuntimeOnly         'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2' // 테스트 전용 인메모리 DB
+
+    // ===== REST Docs =====
+    // MockMvc 기반 테스트에서 스니펫 자동 생성
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    // AsciiDoc 빌드 시 스니펫을 HTML로 변환하는 Asciidoctor 확장
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 // QueryDSL Q클래스 생성 경로를 컴파일 소스에 포함
@@ -138,7 +150,35 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
+    systemProperty 'spring.cloud.config.enabled', 'false'
+}
+
+asciidoctor {
+    inputs.dir snippetsDir // 스니펫 디렉토리를 입력으로 등록
+    dependsOn test // test 완료 후 실행
+    configurations 'asciidoctorExt'
+    baseDirFollowsSourceFile() // .adoc 파일 기준으로 include:: 상대 경로 해석
+}
+
+// 기존 static/docs 디렉토리를 초기화하여 이전 빌드 산출물 충돌 방지
+tasks.named('asciidoctor') {
+    doFirst {
+        delete file('src/main/resources/static/docs')
+    }
+}
+
+// 빌드된 HTML 문서를 Spring Boot static 리소스 경로로 복사
+// app 실행 시 /docs/index.html 로 접근 가능
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from layout.buildDirectory.dir("docs/asciidoc")
+    into layout.projectDirectory.dir("src/main/resources/static/docs")
+}
+
+tasks.named('build') {
+    dependsOn copyDocument
 }
 
 // clean 시 Q클래스 생성 디렉토리도 함께 삭제
@@ -147,6 +187,11 @@ clean {
 }
 
 // ECS 배포 시 이미지 레이어 최적화를 위해 파일명 고정
+// 빌드된 REST Docs HTML을 JAR 내부 static/docs 경로에 포함
 bootJar {
-	archiveFileName = 'app.jar'
+    archiveFileName = 'app.jar'
+    dependsOn asciidoctor
+    from(layout.buildDirectory.dir("docs/asciidoc")) {
+        into 'static/docs'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -162,16 +162,11 @@ asciidoctor {
     baseDirFollowsSourceFile() // .adoc 파일 기준으로 include:: 상대 경로 해석
 }
 
-// 기존 static/docs 디렉토리를 초기화하여 이전 빌드 산출물 충돌 방지
-tasks.named('asciidoctor') {
-    doFirst {
-        delete file('src/main/resources/static/docs')
-    }
-}
+
 
 // 빌드된 HTML 문서를 Spring Boot static 리소스 경로로 복사
 // app 실행 시 /docs/index.html 로 접근 가능
-tasks.register('copyDocument', Copy) {
+tasks.register('copyDocument', Sync) {
     dependsOn asciidoctor
     from layout.buildDirectory.dir("docs/asciidoc")
     into layout.projectDirectory.dir("src/main/resources/static/docs")


### PR DESCRIPTION
## 🌱 설명
REST Docs 빌드 환경 설정


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) close #19 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 테스트 기반 REST API 문서가 자동 생성되어 애플리케이션에 포함됩니다.
  * 생성된 HTML 문서가 애플리케이션 정적 리소스에 복사되어 배포 시 제공됩니다.

* **Chores**
  * 빌드 파이프라인에 문서 생성 및 패키징 단계가 추가되어 빌드 시 문서가 자동으로 생성·포함됩니다.
  * 테스트 실행 시 문서 스니펫이 출력되도록 테스트 구성이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->