### PR TITLE
[feat][user-service] 비밀번호 변경 API 구현 (POST /api/v1/users/me/password)

### DIFF
--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
 import com.firstticket.userservice.application.dto.command.LoginCommand;
 import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
 import com.firstticket.userservice.application.dto.command.SignupCommand;
@@ -382,6 +383,79 @@ public class UserCommandService {
         refreshTokenStore.delete(user.getId());
 
         log.info("[withdraw] 회원탈퇴 완료 - userId: {}", mask(user.getId()));
+    }
+
+    /**
+     * 비밀번호 변경 (본인)
+     *
+     * 처리 흐름
+     * 1. keycloakId로 사용자 조회 (없으면 404)
+     * 2. DELETED 상태 차단 (410)
+     * 3. 새 비밀번호 형식 검증 — Password VO (8자 이상, 100자 이하)
+     * 4. 현재 비밀번호 검증 — Keycloak ROPC 로그인 시도
+     *    실패 시 WRONG_CURRENT_PASSWORD (401)
+     * 5. Keycloak Admin API로 비밀번호 변경
+     *
+     * 설계 결정 사항
+     * - 비밀번호는 Keycloak이 관리하므로 DB 변경 없음 → @Transactional(readOnly = true)
+     * - 현재 비밀번호 검증에 keycloakAuthService.login()을 재사용합니다.
+     *   별도 "비밀번호 확인" Keycloak API가 없으므로 ROPC 흐름이 가장 단순한 검증 수단입니다.
+     * - login() 성공으로 발급된 토큰은 사용하지 않고 버립니다 (검증 목적으로만 호출).
+     *
+     * 추후 확장 포인트 (Notification Service 연동 시)
+     * - 3번과 4번 사이에 이메일 인증 코드 검증 단계를 삽입합니다.
+     *   이 메서드 시그니처와 흐름 구조는 유지됩니다.
+     */
+    @Transactional(readOnly = true) // DB 쓰기 없음 - Keycloak 전용 작업
+    public void changePassword(String keycloakId, ChangePasswordCommand command) {
+        Objects.requireNonNull(keycloakId, "keycloakId는 null일 수 없습니다.");
+
+        // 1. keycloakId로 사용자 조회
+        User user = userRepository.findByKeycloakId(keycloakId)
+            .orElseThrow(() -> {
+                log.warn("[changePassword] 존재하지 않는 사용자 - keycloakId: {}", mask(keycloakId));
+                return new UserException(UserErrorCode.USER_NOT_FOUND);
+            });
+
+        // 2. 탈퇴 상태 사용자의 접근 차단
+        if (user.getStatus() == UserStatus.DELETED) {
+            log.warn("[changePassword] 탈퇴한 사용자 비밀번호 변경 시도 - userId: {}", mask(user.getId()));
+            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
+        }
+
+        // 3. 새 비밀번호 형식 검증
+        // 검증만 목적으로 생성하며 저장하지 않음 (비밀번호는 Keycloak이 관리)
+        Password.of(command.newPassword());
+
+        // TODO: verificationCodeStore.verify(user.getEmail(), command.verificationCode());
+        // 이메일 인증코드 검사 로직 위치
+
+        // 4. 현재 비밀번호 검증 - Keycloak ROPC로 실제 자격증명 확인
+        // 검증 성공 후 발급된 세션은 즉시 revoke하여 고아 세션 누적을 방지
+        try {
+            TokenResult verificationToken =
+                keycloakAuthService.login(user.getEmail(), command.currentPassword());
+            // 검증 목적으로만 사용한 세션 즉시 revoke (비밀번호 변경과 무관하게 항상 수행)
+            keycloakAuthService.revokeToken(verificationToken.refreshToken());
+        } catch (UserException e) {
+            if (e.getErrorCode() == UserErrorCode.INVALID_CREDENTIALS) {
+                log.warn("[changePassword] 현재 비밀번호 불일치 - userId: {}", mask(user.getId()));
+                throw new UserException(UserErrorCode.WRONG_CURRENT_PASSWORD);
+            }
+            log.error("[changePassword] 비밀번호 검증 중 예상치 못한 오류 - userId: {}, errorCode: {}",
+                mask(user.getId()), e.getErrorCode());
+            throw e;
+        } catch (RuntimeException e) {
+            log.error("[changePassword] 현재 비밀번호 검증 중 Keycloak 서버 오류 - userId: {}",
+                mask(user.getId()), e);
+            throw e;
+        }
+
+        // 5. Keycloak Admin API로 비밀번호 변경
+        // 실패 시 KEYCLOAK_PASSWORD_CHANGE_FAILED (500) 발생
+        keycloakAuthService.changePassword(user.getKeycloakId(), command.newPassword());
+
+        log.info("[changePassword] 비밀번호 변경 완료 - userId: {}", mask(user.getId()));
     }
 
     //UUID 마스킹

--- a/src/main/java/com/firstticket/userservice/application/dto/command/ChangePasswordCommand.java
+++ b/src/main/java/com/firstticket/userservice/application/dto/command/ChangePasswordCommand.java
@@ -1,0 +1,23 @@
+package com.firstticket.userservice.application.dto.command;
+
+import java.util.Objects;
+
+/**
+ * 설계 결정 사항
+ * - currentPassword: 현재 비밀번호 (Keycloak ROPC 검증용)
+ * - newPassword: 새 비밀번호 (Password VO 형식 검증 후 Keycloak Admin API 전달)
+ *
+ * 추후 확장 포인트
+ * - Notification Service 연동 후 이메일 인증이 도입되면
+ *   verificationCode 필드를 추가하고 Application 계층에서 검증 단계를 삽입
+ */
+public record ChangePasswordCommand(
+    String currentPassword,
+    String newPassword
+) {
+    // compact constructor - Application 계층 경계에서 null 유입 명시적 차단
+    public ChangePasswordCommand {
+        Objects.requireNonNull(currentPassword, "currentPassword는 null일 수 없습니다.");
+        Objects.requireNonNull(newPassword, "newPassword는 null일 수 없습니다.");
+    }
+}

--- a/src/main/java/com/firstticket/userservice/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/firstticket/userservice/domain/exception/UserErrorCode.java
@@ -31,7 +31,11 @@ public enum UserErrorCode implements ErrorCode {
 
     // Keycloak
     ROLE_ASSIGN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "keycloak 사용자 권한 설정에 실패했습니다."),
-    KEYCLOAK_USER_DISABLE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Keycloak 사용자 비활성화에 실패했습니다.");
+    KEYCLOAK_USER_DISABLE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Keycloak 사용자 비활성화에 실패했습니다."),
+    KEYCLOAK_PASSWORD_CHANGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Keycloak 비밀번호 변경에 실패했습니다."),
+
+    // 비밀번호 변경
+    WRONG_CURRENT_PASSWORD(HttpStatus.UNPROCESSABLE_ENTITY, "현재 비밀번호가 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/userservice/domain/service/KeycloakAuthService.java
+++ b/src/main/java/com/firstticket/userservice/domain/service/KeycloakAuthService.java
@@ -71,4 +71,29 @@ public interface KeycloakAuthService {
      * - 운영 환경에서는 이 메서드를 호출하지 않습니다. (@Profile("local") 컴포넌트 전용)
      */
     void deleteUser(String keycloakId);
+
+    /**
+     * Keycloak 사용자 비밀번호를 변경합니다.
+     *
+     * 설계 결정 사항
+     * - Keycloak Admin Client의 resetPassword() API를 사용합니다.
+     *   (POST /admin/realms/{realm}/users/{id}/reset-password)
+     *
+     * 추후 확장
+     * - Notification Service 구현 시 이메일 통한 인증 코드 검증을 호출부(Application 계층)에서
+     *   이 메서드 호출 전에 추가
+     *
+     * @param keycloakId  비밀번호를 변경할 사용자의 Keycloak UUID
+     * @param newPassword 새 비밀번호 (평문, Keycloak이 해싱 담당)
+     */
+    void changePassword(String keycloakId, String newPassword);
+
+    /**
+     * 검증 목적으로 발급된 Keycloak 세션을 즉시 revoke합니다.
+     * revoke해주지 않으면 반복 호출시 계속 세션이 쌓이는 현상 발견 > 별도 revoke 호출로 처리
+     * Token Revocation Endpoint: POST /realms/{realm}/protocol/openid-connect/revoke
+     *
+     * @param refreshToken revoke할 refresh token
+     */
+    void revokeToken(String refreshToken);
 }

--- a/src/main/java/com/firstticket/userservice/infrastructure/provider/KeycloakAuthServiceImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/provider/KeycloakAuthServiceImpl.java
@@ -314,6 +314,50 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
     }
 
     /**
+     * Keycloak Token Revocation Endpoint 호출
+     * - 비밀번호 변경 시 현재 비밀번호 검증을 위해 발급된 고아 세션을 즉시 종료
+     */
+    @Override
+    public void revokeToken(String refreshToken) {
+        String revokeUrl = buildRevokeUrl();
+
+        MultiValueMap<String, String> formBody = new LinkedMultiValueMap<>();
+        formBody.add("token", refreshToken);
+        formBody.add("token_type_hint", "refresh_token");
+        formBody.add("client_id", keycloakProperties.clientId());
+        formBody.add("client_secret", keycloakProperties.clientSecret());
+
+        try {
+            keycloakRestClient.post()
+                .uri(revokeUrl)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(formBody)
+                .retrieve()
+                .toBodilessEntity(); // revocation 응답은 body 없음 (200 OK만 확인)
+
+            log.debug("[Keycloak] 검증용 토큰 revoke 완료");
+
+        } catch (Exception e) {
+            // revoke 실패는 세션이 TTL까지 잔존하는 것뿐
+            // 이미 비밀번호가 변경되어 해당 세션의 토큰은 실질적으로 무효화됨
+            // 비밀번호 변경 자체를 롤백할 이유가 없으므로 경고 로그만 남김
+            log.warn("[Keycloak] 검증용 토큰 revoke 실패 (비밀번호 변경은 유지됨) - message: {}",
+                e.getMessage());
+        }
+    }
+
+    /**
+     * Keycloak Token Revocation Endpoint URL
+     */
+    private String buildRevokeUrl() {
+        return String.format(
+            "%s/realms/%s/protocol/openid-connect/revoke",
+            keycloakProperties.serverUrl(),
+            keycloakProperties.realm()
+        );
+    }
+
+    /**
      * Keycloak 사용자 계정 비활성화
      *
      * Admin Client로 UserRepresentation을 가져와 enabled = false 로 업데이트합니다.
@@ -424,6 +468,39 @@ public class KeycloakAuthServiceImpl implements KeycloakAuthService {
             // 이미 삭제된 사용자거나 존재하지 않는 경우 → 초기화 중이므로 경고만 기록하고 계속 진행
             log.warn("[deleteUser] Keycloak 사용자 삭제 실패 (무시) - keycloakId: {}, message: {}",
                 mask(keycloakId), e.getMessage());
+        }
+    }
+
+    /**
+     * Keycloak Admin Client를 통해 비밀번호를 재설정
+     *
+     * Keycloak REST API: PUT /admin/realms/{realm}/users/{id}/reset-password
+     * - CredentialRepresentation: type = "password", value = 새 비밀번호, temporary = false
+     * - temporary = false: 임시 비밀번호가 아니므로 로그인 후 강제 변경 요구 없음 (keycloak 설정)
+     */
+    @Override
+    public void changePassword(String keycloakId, String newPassword) {
+        try {
+            // 비밀번호 자격증명 객체 구성
+            CredentialRepresentation credential = new CredentialRepresentation();
+            credential.setType(CredentialRepresentation.PASSWORD); // "password" 타입 고정
+            credential.setValue(newPassword);                      // 평문 비밀번호 (Keycloak이 해싱)
+            credential.setTemporary(false);                        // 로그인 후 강제 변경 없음
+
+            // Admin Client로 비밀번호 재설정 호출
+            // resetPassword()는 성공 시 void 반환, 실패 시 예외 발생
+            keycloakAdminClient
+                .realm(keycloakProperties.realm())
+                .users()
+                .get(keycloakId)          // 대상 사용자 리소스 선택
+                .resetPassword(credential); // PUT /admin/realms/{realm}/users/{id}/reset-password
+
+            log.info("[Keycloak] 비밀번호 변경 완료 - keycloakId: {}", mask(keycloakId));
+
+        } catch (Exception e) {
+            // Keycloak Admin Client 예외를 도메인 예외로 변환 - 인프라 예외가 상위 계층에 누출되지 않도록 차단
+            log.error("[Keycloak] 비밀번호 변경 실패 - keycloakId: {}", mask(keycloakId), e);
+            throw new UserException(UserErrorCode.KEYCLOAK_PASSWORD_CHANGE_FAILED);
         }
     }
 

--- a/src/main/java/com/firstticket/userservice/presentation/UserController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserController.java
@@ -19,6 +19,7 @@ import com.firstticket.userservice.application.UserQueryService;
 import com.firstticket.userservice.application.dto.command.UpdateProfileCommand;
 import com.firstticket.userservice.application.dto.result.HostRequestResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
+import com.firstticket.userservice.presentation.dto.request.ChangePasswordRequest;
 import com.firstticket.userservice.presentation.dto.request.UpdateProfileRequest;
 import com.firstticket.userservice.presentation.dto.response.HostRequestResponse;
 import com.firstticket.userservice.presentation.dto.response.UserResponse;
@@ -113,6 +114,40 @@ public class UserController {
         UUID keycloakId = AuthContext.getUserId();
         userCommandService.withdraw(keycloakId.toString());
         return ApiResponse.success(UserSuccessCode.WITHDRAW_SUCCESS);
+    }
+
+    /**
+     * 본인 비밀번호 변경 API
+     * POST /api/v1/users/me/password
+     *
+     * Gateway의 X-User-Id 헤더(keycloakId)로 본인을 식별합니다.
+     * 현재 비밀번호 확인 후 새 비밀번호로 변경합니다.
+     *
+     * @param request currentPassword (현재 비밀번호), newPassword (새 비밀번호)
+     * @return 200 OK (비밀번호 변경 완료)
+     *
+     * 오류 응답:
+     *   400 Bad Request  — currentPassword/newPassword 빈 값 (@NotBlank 위반)
+     *   400 Bad Request  — newPassword 8자 미만 (Password VO 검증 실패)
+     *   401 Unauthorized — X-User-Id 헤더 누락 (Gateway 미인증 요청)
+     *   422 Unprocessable Entity — currentPassword 불일치 (도메인 규칙 위반, WRONG_CURRENT_PASSWORD)
+     *   404 Not Found    — 사용자 없음
+     *   410 Gone         — 이미 탈퇴된 사용자
+     *
+     * 설계 결정 사항
+     * - 추후 Notification Service 연동 시 이메일 인증 코드 검증 단계를 Service 계층에 추가합니다.
+     */
+    @PostMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+        @RequestBody @Valid ChangePasswordRequest request
+    ) {
+        // AuthContext에서 Gateway가 주입한 X-User-Id(keycloakId) 추출
+        UUID keycloakId = AuthContext.getUserId();
+
+        // Application 계층에 위임: 현재 비밀번호 검증 → Keycloak 비밀번호 변경
+        userCommandService.changePassword(keycloakId.toString(), request.toCommand());
+
+        return ApiResponse.success(UserSuccessCode.PASSWORD_CHANGED);
     }
 
     /**

--- a/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
+++ b/src/main/java/com/firstticket/userservice/presentation/UserSuccessCode.java
@@ -31,7 +31,8 @@ public enum UserSuccessCode implements SuccessCode {
 
     // 내 정보 수정 / 회원탈퇴
     PROFILE_UPDATED(HttpStatus.OK, "회원 정보가 수정되었습니다."),       // 200
-    WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴가 완료되었습니다.");      // 200
+    WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),      // 200
+    PASSWORD_CHANGED(HttpStatus.OK, "비밀번호가 변경되었습니다."); // 200
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/userservice/presentation/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/firstticket/userservice/presentation/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,28 @@
+package com.firstticket.userservice.presentation.dto.request;
+
+import java.util.Objects;
+
+import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
+import jakarta.validation.constraints.NotBlank;
+
+// 비밀번호 변경 요청 DTO (Presentation 계층)
+public record ChangePasswordRequest(
+
+    @NotBlank(message = "현재 비밀번호를 입력해 주세요.")
+    String currentPassword,  // 현재 사용 중인 비밀번호
+
+    @NotBlank(message = "새 비밀번호를 입력해 주세요.")
+    String newPassword       // 변경할 새 비밀번호
+
+) {
+    // compact constructor - @Valid 없이 직접 생성 시에도 null 유입 차단
+    public ChangePasswordRequest {
+        Objects.requireNonNull(currentPassword, "currentPassword는 null일 수 없습니다.");
+        Objects.requireNonNull(newPassword, "newPassword는 null일 수 없습니다.");
+    }
+
+    // Presentation DTO → Application Command 변환
+    public ChangePasswordCommand toCommand() {
+        return new ChangePasswordCommand(currentPassword, newPassword);
+    }
+}

--- a/src/test/java/com/firstticket/userservice/application/UserCommandServiceTest.java
+++ b/src/test/java/com/firstticket/userservice/application/UserCommandServiceTest.java
@@ -1,5 +1,6 @@
 package com.firstticket.userservice.application;
 
+import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
 import com.firstticket.userservice.application.dto.command.LoginCommand;
 import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
 import com.firstticket.userservice.application.dto.command.SignupCommand;
@@ -30,6 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+
+import org.mockito.InOrder;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -456,6 +461,139 @@ class UserCommandServiceTest {
                 .isInstanceOf(UserException.class)
                 .extracting("errorCode")
                 .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 변경(changePassword)")
+    class ChangePassword {
+
+        // 테스트 전용 비밀번호 픽스처 (Password VO 최소 요건인 8자 이상 충족)
+        private static final String CURRENT_PW = "CurrentPass1!";
+        private static final String NEW_PW     = "NewPassword1!";
+
+        @Test
+        @DisplayName("정상 변경 시 Keycloak 현재 비밀번호 검증 후 새 비밀번호로 변경한다")
+        void 정상_비밀번호_변경() {
+            // given
+            User user = activeUser();
+            ChangePasswordCommand command = new ChangePasswordCommand(CURRENT_PW, NEW_PW);
+
+            when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user));
+            // login()은 현재 비밀번호 검증 목적으로 호출 - 반환된 토큰은 서비스에서 버림
+            when(keycloakAuthService.login(anyString(), anyString()))
+                .thenReturn(new TokenResult("access-token", "refresh-token"));
+
+            // when
+            userCommandService.changePassword(KEYCLOAK_ID, command);
+
+            // 현재 비밀번호 검증 후 변경 - 흐름 순서를 테스트로 명시
+            InOrder inOrder = inOrder(keycloakAuthService);
+            inOrder.verify(keycloakAuthService).login(anyString(), anyString());
+            inOrder.verify(keycloakAuthService).changePassword(KEYCLOAK_ID, NEW_PW);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자이면 USER_NOT_FOUND 예외가 발생하고 Keycloak을 호출하지 않는다")
+        void 사용자_없음_예외() {
+            // given
+            when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.empty());
+            ChangePasswordCommand command = new ChangePasswordCommand(CURRENT_PW, NEW_PW);
+
+            // when & then
+            assertThatThrownBy(() -> userCommandService.changePassword(KEYCLOAK_ID, command))
+                .isInstanceOf(UserException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+
+            // 사용자가 없으면 Keycloak 호출이 일어나서는 안 됨 (불필요한 외부 호출 방지)
+            verify(keycloakAuthService, never()).login(anyString(), anyString());
+            verify(keycloakAuthService, never()).changePassword(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("DELETED 사용자이면 USER_ALREADY_DELETED 예외가 발생한다")
+        void 탈퇴된_사용자_예외() {
+            // given — softDelete() 호출로 DELETED 상태 User 생성
+            User deletedUser = activeUser();
+            deletedUser.softDelete(UUID.randomUUID());
+
+            ChangePasswordCommand command = new ChangePasswordCommand(CURRENT_PW, NEW_PW);
+            when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(deletedUser));
+
+            // when & then
+            assertThatThrownBy(() -> userCommandService.changePassword(KEYCLOAK_ID, command))
+                .isInstanceOf(UserException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.USER_ALREADY_DELETED);
+
+            // 탈퇴 상태 차단 이후 Keycloak 호출 없어야 함
+            verify(keycloakAuthService, never()).login(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("현재 비밀번호가 틀리면 INVALID_CREDENTIALS가 WRONG_CURRENT_PASSWORD로 변환되어 발생한다")
+        void 현재_비밀번호_불일치_예외() {
+            // given - Keycloak ROPC 로그인 실패 시나리오
+            User user = activeUser();
+            ChangePasswordCommand command = new ChangePasswordCommand("WrongPass1!", NEW_PW);
+
+            when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user));
+            // 현재 비밀번호 검증 실패: INVALID_CREDENTIALS → WRONG_CURRENT_PASSWORD로 래핑
+            when(keycloakAuthService.login(anyString(), anyString()))
+                .thenThrow(new UserException(UserErrorCode.INVALID_CREDENTIALS));
+
+            // when & then
+            assertThatThrownBy(() -> userCommandService.changePassword(KEYCLOAK_ID, command))
+                .isInstanceOf(UserException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.WRONG_CURRENT_PASSWORD);
+
+            // 현재 비밀번호 검증 실패 시 Keycloak 비밀번호 변경은 호출되지 않아야 함
+            verify(keycloakAuthService, never()).changePassword(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("Keycloak 비밀번호 변경 API가 실패하면 KEYCLOAK_PASSWORD_CHANGE_FAILED 예외가 발생한다")
+        void Keycloak_변경_실패_예외() {
+            // given - 현재 비밀번호 검증은 성공, 변경 API에서 장애 발생 시나리오
+            User user = activeUser();
+            ChangePasswordCommand command = new ChangePasswordCommand(CURRENT_PW, NEW_PW);
+
+            when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user));
+            when(keycloakAuthService.login(anyString(), anyString()))
+                .thenReturn(new TokenResult("access-token", "refresh-token"));
+            // Keycloak Admin API 호출 실패 — Infrastructure 계층에서 이미 래핑된 예외 전파
+            doThrow(new UserException(UserErrorCode.KEYCLOAK_PASSWORD_CHANGE_FAILED))
+                .when(keycloakAuthService).changePassword(anyString(), anyString());
+
+            // when & then
+            assertThatThrownBy(() -> userCommandService.changePassword(KEYCLOAK_ID, command))
+                .isInstanceOf(UserException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.KEYCLOAK_PASSWORD_CHANGE_FAILED);
+        }
+
+        @Test
+        @DisplayName("새 비밀번호가 8자 미만이면 INVALID_PASSWORD_FORMAT 예외가 발생하고 Keycloak을 호출하지 않는다")
+        void 새_비밀번호_형식_불량_예외() {
+            // given
+            // @NotBlank(Presentation 계층)는 통과하지만 Password VO 최소 길이(8자)를 위반하는 값
+            // 서비스 3단계: Password.of(command.newPassword()) 에서 INVALID_PASSWORD_FORMAT 발생
+            User user = activeUser();
+            ChangePasswordCommand command = new ChangePasswordCommand(CURRENT_PW, "Short1!"); // 7자
+
+            when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> userCommandService.changePassword(KEYCLOAK_ID, command))
+                .isInstanceOf(UserException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.INVALID_PASSWORD_FORMAT);
+
+            // 형식 검증(3단계) 실패 → 현재 비밀번호 검증(4단계)과 Keycloak 변경(5단계) 모두 호출 금지
+            verify(keycloakAuthService, never()).login(anyString(), anyString());
+            verify(keycloakAuthService, never()).changePassword(anyString(), anyString());
         }
     }
 }

--- a/src/test/java/com/firstticket/userservice/presentation/UserControllerTest.java
+++ b/src/test/java/com/firstticket/userservice/presentation/UserControllerTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -351,6 +352,152 @@ class UserControllerTest {
         void 인증_없음_401() throws Exception {
             // when & then
             mockMvc.perform(post("/api/v1/users/me/host-requests"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/users/me/password - 비밀번호 변경")
+    class ChangePassword {
+
+        @Test
+        @DisplayName("유효한 현재/새 비밀번호로 요청 시 200 OK + PASSWORD_CHANGED를 반환한다")
+        void 비밀번호_변경_성공() throws Exception {
+            // given — void 반환 메서드이므로 doNothing 사용
+            doNothing().when(userCommandService).changePassword(any(), any());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/users/me/password")
+                    .header("X-User-Id", USER_ID.toString())   // Gateway가 JWT sub에서 주입한 헤더
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                      {
+                        "currentPassword": "CurrentPass1!",
+                        "newPassword": "NewPassword1!"
+                      }
+                      """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("PASSWORD_CHANGED"))
+                .andDo(document("user-change-password",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName("X-User-Id").description("Gateway가 JWT sub 클레임에서 추출하여 주입한 사용자 UUID")
+                    ),
+                    requestFields(
+                        fieldWithPath("currentPassword").description("현재 사용 중인 비밀번호"),
+                        fieldWithPath("newPassword").description("변경할 새 비밀번호 (8자 이상)")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드 (PASSWORD_CHANGED)"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("currentPassword가 빈 값이면 @NotBlank 위반으로 400 Bad Request를 반환한다")
+        void currentPassword_빈값_400() throws Exception {
+            // given — @NotBlank 검증 실패 → GlobalExceptionHandler → INVALID_INPUT (400)
+
+            mockMvc.perform(post("/api/v1/users/me/password")
+                    .header("X-User-Id", USER_ID.toString())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                      {
+                        "currentPassword": "",
+                        "newPassword": "NewPassword1!"
+                      }
+                      """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andDo(document("user-change-password-invalid-current",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (INVALID_INPUT)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("newPassword가 빈 값이면 @NotBlank 위반으로 400 Bad Request를 반환한다")
+        void newPassword_빈값_400() throws Exception {
+            // given — @NotBlank 검증 실패 → GlobalExceptionHandler → INVALID_INPUT (400)
+
+            mockMvc.perform(post("/api/v1/users/me/password")
+                    .header("X-User-Id", USER_ID.toString())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                      {
+                        "currentPassword": "CurrentPass1!",
+                        "newPassword": ""
+                      }
+                      """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andDo(document("user-change-password-invalid-new",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (INVALID_INPUT)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("현재 비밀번호가 틀리면 422 Unprocessable Entity + WRONG_CURRENT_PASSWORD를 반환한다")
+        void 현재_비밀번호_불일치_422() throws Exception {   // 메서드명도 422로 변경
+            doThrow(new UserException(UserErrorCode.WRONG_CURRENT_PASSWORD))
+                .when(userCommandService).changePassword(any(), any());
+
+            mockMvc.perform(post("/api/v1/users/me/password")
+                    .header("X-User-Id", USER_ID.toString())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                  {
+                    "currentPassword": "WrongPass1!",
+                    "newPassword": "NewPassword1!"
+                  }
+                  """))
+                .andExpect(status().isUnprocessableEntity())    // 422
+                .andExpect(jsonPath("$.code").value("WRONG_CURRENT_PASSWORD"))
+                .andDo(document("user-change-password-wrong-current",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (WRONG_CURRENT_PASSWORD)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+
+        @Test
+        @DisplayName("X-User-Id 헤더가 없으면 401 Unauthorized + UNAUTHORIZED를 반환한다")
+        void 인증_헤더_없음_401() throws Exception {
+            // given — Gateway가 X-User-Id를 주입하지 않은 경우 (비인증 요청)
+            // AuthContext.getUserId() → BusinessException(UNAUTHORIZED)
+
+            mockMvc.perform(post("/api/v1/users/me/password")
+                    .contentType(MediaType.APPLICATION_JSON)   // X-User-Id 헤더 생략
+                    .content("""
+                      {
+                        "currentPassword": "CurrentPass1!",
+                        "newPassword": "NewPassword1!"
+                      }
+                      """))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
         }


### PR DESCRIPTION


## 🌱 설명
- Keycloak ROPC로 현재 비밀번호 검증 후 Admin API로 신규 비밀번호 변경
- 검증용 토큰을 RFC 7009 Token Revocation으로 즉시 폐기 (고아 세션 방지)
- WRONG_CURRENT_PASSWORD 응답 코드 401 → 422 Unprocessable Entity 수정 (api-response.md 컨벤션: 도메인 규칙 위반은 422)
- ChangePasswordRequest/Command compact constructor 추가 (null 방어)
- catch 블록에 userId/errorCode 컨텍스트 로그 추가 및 RuntimeException 분리 처리
- UserCommandService/UserController 단위 테스트 11건 추가


## 📌 관련 이슈
- close #39 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [x] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명

### 비밀번호 변경 플로우

```
Client → Gateway (JWT 검증) → POST /api/v1/users/me/password
    └─ UserCommandService.changePassword()
         ├─ 1. User 조회 (keycloakId → DB)
         ├─ 2. Password.of(newPassword) → 형식 검증 (8자 이상)
         ├─ 3. keycloakAuthService.login(email, currentPassword) → 현재 비밀번호 검증 (ROPC)
         ├─ 4. keycloakAuthService.revokeToken(refreshToken) → 검증용 세션 즉시 폐기
         └─ 5. keycloakAuthService.changePassword(keycloakId, newPassword) → 실제 변경
```

### 파일 수정 목록


파일 | 변경 내용
-- | --
UserController.java | POST /api/v1/users/me/password 엔드포인트 추가
UserCommandService.java | changePassword() 메서드 추가
KeycloakAuthService.java | revokeToken() 포트 메서드 추가
KeycloakAuthServiceImpl.java | revokeToken() + buildRevokeUrl() 구현
UserErrorCode.java | WRONG_CURRENT_PASSWORD(422), KEYCLOAK_PASSWORD_CHANGE_FAILED 추가
UserSuccessCode.java | PASSWORD_CHANGED 추가
ChangePasswordCommand.java | 신규 — compact constructor 포함
ChangePasswordRequest.java | 신규 — compact constructor + toCommand() 포함
UserCommandServiceTest.java | ChangePassword 중첩 클래스 6개 테스트 추가
UserControllerTest.java | ChangePassword 중첩 클래스 5개 테스트 추가