### PR TITLE
[feat][user-service] Access Token Blacklist 구현으로 로그아웃 즉시 무효화

### DIFF
--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -1,11 +1,13 @@
 package com.firstticket.userservice.application;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
 import com.firstticket.userservice.application.dto.command.LoginCommand;
+import com.firstticket.userservice.application.dto.command.LogoutCommand;
 import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
 import com.firstticket.userservice.application.dto.command.SignupCommand;
 import com.firstticket.userservice.application.dto.command.UpdateProfileCommand;
@@ -19,6 +21,7 @@ import com.firstticket.userservice.domain.UserRole;
 import com.firstticket.userservice.domain.UserStatus;
 import com.firstticket.userservice.domain.exception.UserErrorCode;
 import com.firstticket.userservice.domain.exception.UserException;
+import com.firstticket.userservice.domain.service.AccessTokenBlacklist;
 import com.firstticket.userservice.domain.service.KeycloakAuthService;
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
 import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult; // ← 추가
@@ -44,6 +47,7 @@ public class UserCommandService {
     private final UserRepository userRepository;
     private final KeycloakAuthService keycloakAuthService;
     private final RefreshTokenStore refreshTokenStore;
+    private final AccessTokenBlacklist accessTokenBlacklist;
 
     /**
      * 회원가입
@@ -196,25 +200,34 @@ public class UserCommandService {
     /**
      * 로그아웃
      * 처리 흐름
-     * 1. Gateway X-User-Id 헤더(keycloakId)로 사용자 조회
-     * 2. Redis에서 Refresh Token 삭제 (이후 토큰 재발급 불가)
+     * 1. Gateway X-User-Id(keycloakId)로 사용자 조회
+     * 2. Redis에서 Refresh Token 삭제 → 재발급 경로 차단
+     * 3. Access Token을 blacklist에 등록 -> 잔여 TTL 동안 즉시 무효화
      *
      * 설계 결정 사항
-     * - Access Token은 만료될 때까지 유효하지만 TTL이 짧으므로(통상 5~15분) 허용 범위로 간주
-     * - Keycloak 세션 revoke는 MVP 범위 외 (추후 /logout 엔드포인트 호출로 보완 가능)
+     * - jti와 tokenExpEpoch는 Gateway AuthorizationHeaderFilter가 JWT에서 추출해 헤더로 주입
+     *   user-service는 JWT 파싱 없이 헤더 값만 사용 (관심사 분리)
+     * - tokenExpEpoch - now <= 0이면 이미 만료된 토큰 → blacklist 저장 생략 (AccessTokenBlacklistImpl 내부 처리)
+     * - blacklist 조회는 Gateway가 Redis를 직접 읽으므로 서비스 간 호출 없음
      */
     @Transactional(readOnly = true)
-    public void logout(String keycloakId) {
-        // 1. keycloakId로 사용자 조회 (없으면 이미 삭제된 계정 또는 비정상 요청)
-        User user = userRepository.findByKeycloakId(keycloakId)
+    public void logout(LogoutCommand command) {
+        // 1. keycloakId로 사용자 조회
+        User user = userRepository.findByKeycloakId(command.keycloakId())
             .orElseThrow(() -> {
-                log.warn("[logout] 사용자 조회 실패 - keycloakId: {}", keycloakId);
+                log.warn("[logout] 사용자 조회 실패 - keycloakId: {}", mask(command.keycloakId()));
                 return new UserException(UserErrorCode.USER_NOT_FOUND);
             });
 
-        // 2. Redis에서 Refresh Token 삭제 → 이후 재발급 불가
+        // 2. Refresh Token 삭제 → 재발급 경로 차단
         refreshTokenStore.delete(user.getId());
-        log.info("[logout] Refresh Token 삭제 완료 - userId: {}", user.getId());
+        log.info("[logout] Refresh Token 삭제 완료 - userId: {}", mask(user.getId()));
+
+        // 3. Access Token blacklist 등록
+        // TTL = 토큰 만료 시각(epoch초) - 현재 시각(epoch초)
+        long ttlSeconds = command.tokenExpEpoch() - Instant.now().getEpochSecond();
+        accessTokenBlacklist.add(command.jti(), ttlSeconds);
+        log.info("[logout] Access Token blacklist 등록 완료 - userId: {}, ttl: {}s", mask(user.getId()), ttlSeconds);
     }
 
     /**

--- a/src/main/java/com/firstticket/userservice/application/dto/command/LogoutCommand.java
+++ b/src/main/java/com/firstticket/userservice/application/dto/command/LogoutCommand.java
@@ -1,0 +1,22 @@
+package com.firstticket.userservice.application.dto.command;
+
+import java.util.Objects;
+
+/**
+ * 설계 결정 사항
+ * - keycloakId: Gateway X-User-Id 헤더 -> Refresh Token 삭제에 사용
+ * - jti: Gateway X-Jti 헤더 -> Access Token blacklist 등록 key
+ * - tokenExpEpoch: Gateway X-Token-Exp 헤더 (epoch 초) -> Redis TTL 계산
+ *   TTL = tokenExpEpoch - now (초 단위). 음수이면 이미 만료된 토큰
+ */
+public record LogoutCommand(
+    String keycloakId,
+    String jti,
+    long tokenExpEpoch
+) {
+    // compact constructor - null 유입 방어
+    public LogoutCommand {
+        Objects.requireNonNull(keycloakId, "keycloakId는 null일 수 없습니다.");
+        Objects.requireNonNull(jti, "jti는 null일 수 없습니다.");
+    }
+}

--- a/src/main/java/com/firstticket/userservice/domain/service/AccessTokenBlacklist.java
+++ b/src/main/java/com/firstticket/userservice/domain/service/AccessTokenBlacklist.java
@@ -1,0 +1,18 @@
+package com.firstticket.userservice.domain.service;
+
+/**
+ * Access Token Blacklist 저장소 Port
+ *
+ * 설계 결정 사항
+ * - domain 계층 인터페이스로 선언하여 infrastructure(Redis) 직접 의존 차단
+ * - 키: "blacklist:{jti}" - Access Token의 JWT ID 클레임 기반
+ * - TTL: 로그아웃 시점의 토큰 잔여 만료 시간 → TTL 경과 후 Redis에서 자동 삭제
+ */
+public interface AccessTokenBlacklist {
+
+    // Access Token을 blacklist에 등록
+    void add(String jti, long ttlSeconds);
+
+    // Access Token이 blacklist에 등록되어 있는지 확인
+    boolean isBlacklisted(String jti);
+}

--- a/src/main/java/com/firstticket/userservice/infrastructure/redis/AccessTokenBlacklistImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/redis/AccessTokenBlacklistImpl.java
@@ -1,0 +1,66 @@
+package com.firstticket.userservice.infrastructure.redis;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.firstticket.userservice.domain.service.AccessTokenBlacklist;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * AccessTokenBlacklist Redis 구현체
+ *
+ * 설계 결정 사항
+ * - key 패턴: "blacklist:{jti}"
+ * - value: "1" (존재 여부만 체크)
+ * - TTL은 호출자(UserCommandService)가 계산해서 전달 - 구현체는 저장만 담당
+ * - Gateway가 같은 Redis 인스턴스를 바라보므로 prefix 충돌에 유의
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessTokenBlacklistImpl implements AccessTokenBlacklist {
+
+    // StringRedisTemplate - RefreshTokenStoreImpl과 동일한 빈 재사용
+    private final StringRedisTemplate redisTemplate;
+
+    // Redis key 네임스페이스 - "refresh:" 와 구분
+    private static final String KEY_PREFIX = "blacklist:";
+
+    @Override
+    public void add(String jti, long ttlSeconds) {
+        // SET blacklist:{jti} "1" EX {ttlSeconds}
+        // ttlSeconds <= 0이면 이미 만료된 토큰이므로 저장 생략
+        if (ttlSeconds <= 0) {
+            log.debug("[blacklist] 이미 만료된 토큰 - blacklist 등록 생략, jti prefix: {}", abbreviated(jti));
+            return;
+        }
+        redisTemplate.opsForValue().set(
+            buildKey(jti),   // "blacklist:{jti}"
+            "1",             // 값은 존재 여부만 필요 - "1" 고정
+            ttlSeconds,
+            TimeUnit.SECONDS
+        );
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        // Boolean.TRUE.equals(null) == false — null 반환 시 NPE 없이 false 처리
+        // StringRedisTemplate.hasKey()는 연결 이상 등 일부 케이스에서 null을 반환할 수 있음
+        return Boolean.TRUE.equals(redisTemplate.hasKey(buildKey(jti)));
+    }
+
+    // Redis key 생성: "blacklist:{jti}"
+    private String buildKey(String jti) {
+        return KEY_PREFIX + jti;
+    }
+
+    //  원문 노출 방지
+    private String abbreviated(String jti) {
+        if (jti == null || jti.length() <= 8) return "****";
+        return jti.substring(0, 8) + "...";
+    }
+}

--- a/src/main/java/com/firstticket/userservice/presentation/AuthController.java
+++ b/src/main/java/com/firstticket/userservice/presentation/AuthController.java
@@ -2,6 +2,7 @@ package com.firstticket.userservice.presentation;
 
 import com.firstticket.common.response.ApiResponse;
 import com.firstticket.userservice.application.UserCommandService;
+import com.firstticket.userservice.application.dto.command.LogoutCommand;
 import com.firstticket.userservice.application.dto.result.TokenResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
 import com.firstticket.userservice.presentation.dto.request.LoginRequest;
@@ -79,7 +80,9 @@ public class AuthController {
      * 로그아웃 API
      * Gateway에서 주입한 X-User-Id 헤더(keycloakId)를 사용하여 Redis의 Refresh Token을 삭제합니다.
      *
-     * @param keycloakId Gateway AuthorizationHeaderFilter가 JWT sub 클레임에서 추출하여 주입
+     * @param keycloakId  X-User-Id  — JWT sub 클레임 (Gateway 주입)
+     * @param jti         X-Jti      — JWT jti 클레임 (Gateway 주입) → blacklist key
+     * @param tokenExpEpoch X-Token-Exp — JWT exp 클레임 epoch 초 (Gateway 주입) → Redis TTL 계산용
      * @return 204 No Content
      *
      * 오류 응답:
@@ -91,11 +94,13 @@ public class AuthController {
      */
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
-        @RequestHeader("X-User-Id") String keycloakId) {
+        @RequestHeader("X-User-Id") String keycloakId,
+        @RequestHeader("X-Jti") String jti,
+        @RequestHeader("X-Token-Exp") long tokenExpEpoch
+    ) {
+        userCommandService.logout(new LogoutCommand(keycloakId, jti, tokenExpEpoch));
 
-        userCommandService.logout(keycloakId);
-
-        // 204 No Content — 응답 body 없음 (RESTful 관례: 삭제/무효화 성공 시 본문 생략)
+        // 204 No Content - 로그아웃 성공, 응답 body 없음
         return ResponseEntity.noContent().build();
     }
 

--- a/src/test/java/com/firstticket/userservice/application/UserCommandServiceTest.java
+++ b/src/test/java/com/firstticket/userservice/application/UserCommandServiceTest.java
@@ -2,6 +2,7 @@ package com.firstticket.userservice.application;
 
 import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
 import com.firstticket.userservice.application.dto.command.LoginCommand;
+import com.firstticket.userservice.application.dto.command.LogoutCommand;
 import com.firstticket.userservice.application.dto.command.RefreshTokenCommand;
 import com.firstticket.userservice.application.dto.command.SignupCommand;
 import com.firstticket.userservice.application.dto.command.UpdateProfileCommand;
@@ -13,6 +14,7 @@ import com.firstticket.userservice.domain.UserRole;
 import com.firstticket.userservice.domain.UserRepository;
 import com.firstticket.userservice.domain.exception.UserErrorCode;
 import com.firstticket.userservice.domain.exception.UserException;
+import com.firstticket.userservice.domain.service.AccessTokenBlacklist;
 import com.firstticket.userservice.domain.service.KeycloakAuthService;
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
 import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult;
@@ -24,15 +26,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 
 import org.mockito.InOrder;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -62,6 +65,9 @@ class UserCommandServiceTest {
 
     @Mock
     private RefreshTokenStore refreshTokenStore;
+
+    @Mock
+    private AccessTokenBlacklist accessTokenBlacklist;
 
     // keycloakId는 Keycloak이 발급하는 UUID 문자열
     private final String KEYCLOAK_ID = UUID.randomUUID().toString();
@@ -202,31 +208,46 @@ class UserCommandServiceTest {
     @DisplayName("로그아웃(logout)")
     class Logout {
 
+        // 테스트용 jti — Keycloak이 발급하는 JWT ID 클레임 형태(UUID)
+        private static final String JTI = UUID.randomUUID().toString();
+
+        // 테스트용 tokenExpEpoch — 현재로부터 15분 후 (Access Token 기본 TTL)
+        // static 필드로 선언하면 클래스 로딩 시점에 1회만 계산되어 일관성 보장
+        private static final long FUTURE_EXP = Instant.now().plusSeconds(900).getEpochSecond();
+
         @Test
-        @DisplayName("정상 로그아웃 시 Redis Refresh Token이 삭제된다")
+        @DisplayName("정상 로그아웃 시 Refresh Token이 삭제되고 Access Token이 blacklist에 등록된다")
         void 정상_로그아웃() {
             // given
             User user = activeUser();
+            LogoutCommand command = new LogoutCommand(KEYCLOAK_ID, JTI, FUTURE_EXP);
             when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user));
 
             // when
-            userCommandService.logout(KEYCLOAK_ID);
+            userCommandService.logout(command);
 
-            // then - Redis 토큰 삭제 1회 호출 검증
-            verify(refreshTokenStore).delete(any());
+            // then — Refresh Token 삭제 + Access Token blacklist 등록 순서로 검증
+            InOrder inOrder = inOrder(refreshTokenStore, accessTokenBlacklist);
+            inOrder.verify(refreshTokenStore).delete(any());           // Refresh Token 삭제
+            inOrder.verify(accessTokenBlacklist).add(anyString(), anyLong()); // blacklist 등록
         }
 
         @Test
-        @DisplayName("존재하지 않는 사용자 로그아웃 시 USER_NOT_FOUND 예외가 발생한다")
+        @DisplayName("존재하지 않는 사용자 로그아웃 시 USER_NOT_FOUND 예외가 발생하고 blacklist 등록이 호출되지 않는다")
         void 사용자_없음_예외() {
             // given
+            LogoutCommand command = new LogoutCommand(KEYCLOAK_ID, JTI, FUTURE_EXP);
             when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> userCommandService.logout(KEYCLOAK_ID))
+            assertThatThrownBy(() -> userCommandService.logout(command))
                 .isInstanceOf(UserException.class)
                 .extracting("errorCode")
                 .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+
+            // 사용자가 없으면 Redis 작업이 일어나서는 안 됨
+            verify(refreshTokenStore, never()).delete(any());
+            verify(accessTokenBlacklist, never()).add(anyString(), anyLong());
         }
     }
 

--- a/src/test/java/com/firstticket/userservice/infrastructure/AccessTokenBlacklistImplTest.java
+++ b/src/test/java/com/firstticket/userservice/infrastructure/AccessTokenBlacklistImplTest.java
@@ -1,0 +1,105 @@
+package com.firstticket.userservice.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.firstticket.userservice.infrastructure.redis.AccessTokenBlacklistImpl;
+
+@ExtendWith(MockitoExtension.class)
+class AccessTokenBlacklistImplTest {
+
+    @InjectMocks
+    private AccessTokenBlacklistImpl blacklist;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    private static final String JTI = "test-jti-uuid";
+
+    @Nested
+    @DisplayName("add()")
+    class Add {
+
+        @Test
+        @DisplayName("유효한 TTL이면 Redis에 blacklist:{jti} 키로 저장한다")
+        void 유효한_TTL_저장() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+            // when
+            blacklist.add(JTI, 900L); // 15분 잔여
+
+            // then
+            verify(valueOps).set(
+                eq("blacklist:" + JTI), // key 형식 검증
+                eq("1"),               // value는 존재 여부만 의미
+                eq(900L),
+                eq(TimeUnit.SECONDS)
+            );
+        }
+
+        @Test
+        @DisplayName("TTL이 0 이하이면 이미 만료된 토큰 — Redis 저장을 생략한다")
+        void 만료된_토큰_저장_생략() {
+            // given — TTL 음수 (이미 만료된 토큰)
+
+            // when
+            blacklist.add(JTI, 0L);
+            blacklist.add(JTI, -1L);
+
+            // then — Redis 호출 없어야 함
+            verify(redisTemplate, never()).opsForValue();
+        }
+    }
+
+    @Nested
+    @DisplayName("isBlacklisted()")
+    class IsBlacklisted {
+
+        @Test
+        @DisplayName("blacklist에 등록된 jti이면 true를 반환한다")
+        void 등록된_jti_true() {
+            // given
+            when(redisTemplate.hasKey("blacklist:" + JTI)).thenReturn(true);
+
+            // when & then
+            assertThat(blacklist.isBlacklisted(JTI)).isTrue();
+        }
+
+        @Test
+        @DisplayName("blacklist에 없는 jti이면 false를 반환한다")
+        void 미등록_jti_false() {
+            // given
+            when(redisTemplate.hasKey("blacklist:" + JTI)).thenReturn(false);
+
+            // when & then
+            assertThat(blacklist.isBlacklisted(JTI)).isFalse();
+        }
+
+        @Test
+        @DisplayName("Redis가 null을 반환하면 false로 처리한다")
+        void Redis_null_반환_false() {
+            // given — Redis hasKey()가 null 반환하는 엣지 케이스
+            when(redisTemplate.hasKey(anyString())).thenReturn(null);
+
+            // when & then
+            assertThat(blacklist.isBlacklisted(JTI)).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/firstticket/userservice/presentation/AuthControllerTest.java
+++ b/src/test/java/com/firstticket/userservice/presentation/AuthControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.Instant;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -251,24 +252,38 @@ class AuthControllerTest {
     @DisplayName("POST /api/v1/auth/logout — 로그아웃")
     class Logout {
 
+        // Gateway AuthorizationHeaderFilter가 JWT에서 추출해 주입하는 헤더 테스트 픽스처
+        private static final String TEST_JTI       = UUID.randomUUID().toString();
+        private static final String TEST_TOKEN_EXP =
+            String.valueOf(Instant.now().plusSeconds(900).getEpochSecond());
+
         @Test
-        @DisplayName("X-User-Id 헤더가 있으면 Redis Refresh Token을 삭제하고 204 No Content를 반환한다")
+        @DisplayName("필수 헤더가 모두 있으면 Refresh Token 삭제 + Access Token blacklist 등록 후 204를 반환한다")
         void 로그아웃_성공() throws Exception {
+            // given — userCommandService.logout()은 void, 정상 처리 모킹
             doNothing().when(userCommandService).logout(any());
             String keycloakId = UUID.randomUUID().toString();
 
+            // when & then
             mockMvc.perform(post("/api/v1/auth/logout")
-                    .header("X-User-Id", keycloakId))
-                .andExpect(status().isNoContent())
+                    // Gateway가 JWT 클레임에서 추출해 주입하는 3개 헤더
+                    .header("X-User-Id",    keycloakId)    // sub: Keycloak 사용자 UUID
+                    .header("X-Jti",        TEST_JTI)      // jti: Access Token blacklist key
+                    .header("X-Token-Exp",  TEST_TOKEN_EXP)) // exp: Redis TTL 계산용 (epoch 초)
+                .andExpect(status().isNoContent())          // 204 No Content
                 .andDo(document("auth-logout",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
-                    requestHeaders(  // ← 기존에 빠져 있던 헤더 문서 추가
-                        headerWithName("X-User-Id").description
-                            ("Gateway가 JWT sub 클레임에서 추출하여 주입한 keycloak 사용자 ID")
-                        )
-                        // 204 No Content — 응답 body 없음
-                    ));
+                    requestHeaders(
+                        headerWithName("X-User-Id")
+                            .description("Gateway가 JWT sub 클레임에서 추출하여 주입한 Keycloak 사용자 UUID"),
+                        headerWithName("X-Jti")
+                            .description("Gateway가 JWT jti 클레임에서 추출하여 주입한 JWT 고유 ID — Access Token blacklist 키"),
+                        headerWithName("X-Token-Exp")
+                            .description("Gateway가 JWT exp 클레임에서 추출하여 주입한 만료 시각 (epoch 초) — Redis TTL 계산용")
+                    )
+                    // 204 No Content — 응답 body 없음
+                ));
         }
     }
 


### PR DESCRIPTION
## 🌱 설명

- JWT는 서명 기반 무상태 토큰으로 서버 측 단독 무효화가 불가능하여, 로그아웃 후에도 Access Token TTL(15분) 동안 유효한 문제가 있었습니다.
- 설계 문서(`architecture/overview.md`)에 명시된 Redis Blacklist를 구현하여 로그아웃 즉시 Access Token을 무효화합니다.
- Gateway가 모든 인증 요청에서 Redis blacklist를 조회하여 등록된 jti는 401로 차단합니다.
- 
## 📌 관련 이슈

- close #41 

## 💻 커밋 유형

- [x] feat     : 새로운 기능 추가

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

### 핵심 플로우

```
[로그아웃]
POST /api/v1/auth/logout
  Gateway → X-Jti, X-Token-Exp 헤더 주입
  user-service → Refresh Token 삭제 + Redis SET blacklist:{jti} "1" EX {잔여TTL}

[모든 인증 요청]
Gateway AuthorizationHeaderFilter
  → Redis EXISTS blacklist:{jti}
  → true면 401 즉시 반환 (user-service 도달 없음)
```



파일 | 변경 내용
-- | --
AccessTokenBlacklist.java | 포트 인터페이스 신규
AccessTokenBlacklistImpl.java | Redis 구현체 신규 (blacklist:{jti}, TTL 자동 만료)
LogoutCommand.java | 신규 — jti, tokenExpEpoch 필드 추가
UserCommandService.java | logout() — blacklist 등록 단계 추가
AuthController.java | logout() — X-Jti, X-Token-Exp 헤더 수신
AccessTokenBlacklistImplTest.java | 단위 테스트 5건 신규
UserCommandServiceTest.java | Logout 테스트 수정
AuthControllerTest.java | Logout 테스트 수정

### ⚠️ gateway-server 동반 PR 필요

이 PR은 **gateway-server PR과 함께 배포**해야 합니다.
- user-service: `blacklist:{jti}` 키 Redis 저장
- gateway-server: 동일 키를 Redis에서 조회하여 401 차단
- 두 서비스가 같은 Redis 인스턴스(`first-ticket-redis`)를 공유해야 동작합니다.
- **키 prefix `blacklist:` 는 두 서비스 간 계약입니다. 단독 변경 금지.**