### PR TITLE
[refactor][user-service] 부하테스트중 장애 해결

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,12 +9,19 @@ build/test-results/
 .env
 *.env
 .gradle/
-gradle/
 
 # IDE / OS 메타데이터
 .idea/
 *.iml
 .DS_Store
 
-# 소스코드 (런타임에 불필요)
-src/
+# Gradle 캐시 및 빌드 결과물
+build/
+
+# Git 메타데이터
+.git/
+.gitignore
+
+# 문서 / 기타
+*.md
+http/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,36 @@
 # user-service 배포용 Dockerfile
-# 전제: GitHub Actions에서 ./gradlew build 완료 후 이미지 빌드
-# 결과물: build/libs/app.jar (bootJar archiveFileName 고정)
-# 배포 대상: AWS ECS Fargate (ECR 이미지 사용)
+FROM eclipse-temurin:21-jdk-alpine AS builder
 
-# 1. 베이스 이미지
+WORKDIR /workspace
+
+COPY gradlew .
+COPY gradle/ gradle/
+RUN chmod +x gradlew
+
+COPY build.gradle settings.gradle ./
+
+COPY src/ src/
+
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+
+RUN GITHUB_USER=${GITHUB_USER} GITHUB_TOKEN=${GITHUB_TOKEN} \
+    ./gradlew bootJar -x test -x asciidoctor --no-daemon
 FROM eclipse-temurin:21-jre-alpine
 
-# 2. 보안 강화 - 전용 비루트 사용자 생성
+# 보안 강화 - 전용 비루트 사용자 생성
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-# 3. 작업 디렉토리 설정
-# /app: 앱 전용 디렉토리. root 소유 파일이 /root에 섞이지 않도록 분리
 WORKDIR /app
 
-# 4. JAR 복사
-COPY build/libs/app.jar app.jar
+COPY --from=builder /workspace/build/libs/app.jar app.jar
 
-# 5. 파일 소유권 변경
 RUN chown appuser:appgroup app.jar
 
 USER appuser
 
-# 7. 포트 선언
 EXPOSE 8080
 
-# 8. JVM 실행 옵션
 ENTRYPOINT ["java", \
   "-XX:+UseContainerSupport", \
   "-XX:MaxRAMPercentage=75.0", \

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,9 @@ dependencies {
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     runtimeOnly 'io.zipkin.reporter2:zipkin-reporter-brave'
 
+    // Keycloak RestClient 커넥션 풀 튜닝용
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
+
 	// ===== Lombok =====
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        GITHUB_USER: ${GITHUB_USER}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
     container_name: first-ticket-user
 
     ports:

--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -4,6 +4,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
 import com.firstticket.userservice.application.dto.command.LoginCommand;
@@ -24,13 +28,10 @@ import com.firstticket.userservice.domain.exception.UserException;
 import com.firstticket.userservice.domain.service.AccessTokenBlacklist;
 import com.firstticket.userservice.domain.service.KeycloakAuthService;
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
-import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult; // ← 추가
+import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 설계 결정 사항
@@ -146,6 +147,34 @@ public class UserCommandService {
                 log.info("[seed] 테스트 계정 생성 완료 - email: {}, role: {}", spec.email(), spec.role());
                 return UserResult.from(saved);
             });
+    }
+
+    /**
+     * 부하테스트 전용 테스트 계정 시드 메서드
+     * @Profile("load-test")에서만 호출됩니다.
+     *
+     * 설계 결정 사항
+     * - 25명 모두 CUSTOMER role: 부하테스트 시나리오(로그인)는 역할 구분이 불필요
+     * - IntStream으로 동적 생성: 계정 수 변경 시 상수만 수정하면 됨
+     * - 이메일 패턴: testuser01~25@test.com (zero-padded → 정렬/가독성)
+     * - 비밀번호 Test1234!: Password VO 검증 통과 조건(대소문자+숫자+특수문자)
+     */
+    @Transactional
+    public List<UserResult> seedLoadTestUsers() {
+        // 25명의 CUSTOMER 계정 명세를 동적 생성 (상수만 바꾸면 vuser 수 조정 가능)
+        int userCount = 200;
+        List<SeedUserSpec> specs = IntStream.rangeClosed(1, userCount)
+            .mapToObj(i -> new SeedUserSpec(
+                String.format("testuser%02d@test.com", i),
+                "Test1234!",
+                String.format("테스트유저%02d", i),
+                UserRole.CUSTOMER
+            ))
+            .toList();
+
+        return specs.stream()
+            .map(this::createOrGetSeedUser) // 기존 멱등성 로직 재사용
+            .toList();
     }
 
     /**

--- a/src/main/java/com/firstticket/userservice/infrastructure/init/LoadTestDataInitializer.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/init/LoadTestDataInitializer.java
@@ -1,0 +1,69 @@
+package com.firstticket.userservice.infrastructure.init;
+
+import com.firstticket.userservice.application.UserCommandService;
+import com.firstticket.userservice.domain.service.KeycloakAuthService;
+import com.firstticket.userservice.infrastructure.persistence.HostRequestJpaRepository;
+import com.firstticket.userservice.infrastructure.persistence.UserJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 부하테스트 환경 전용 데이터 초기화 컴포넌트
+ *
+ * 설계 결정 사항
+ * - @Profile("load-test"): prod/dev 등 기존 환경에 독립적인 별도 프로파일로 운영
+ *   활성화 방법: -Dspring.profiles.active=prod,load-test
+ * - LocalDataInitializer(@Profile("local"))와 목적이 다름:
+ *   Local → 역할별 3종 계정 (개발/기능 테스트용)
+ *   LoadTest → CUSTOMER 25명 (vuser 수만큼 동시 로그인 테스트용)
+ * - 삭제 순서: host_requests → Keycloak → users (FK 제약 준수)
+ * - Keycloak 삭제 실패는 무시하고 진행 (Keycloak과 DB 상태 불일치 허용)
+ */
+@Slf4j
+@Component
+@Profile("load-test") // prod 환경에서도 이 프로파일을 추가해야만 활성화됨
+@RequiredArgsConstructor
+public class LoadTestDataInitializer implements ApplicationRunner {
+
+    private final HostRequestJpaRepository hostRequestJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final KeycloakAuthService keycloakAuthService;
+    private final UserCommandService userCommandService;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        log.info("[LoadTestDataInitializer] ===== 부하테스트 DB / Keycloak 초기화 시작 =====");
+
+        // 1. host_requests 전체 삭제 (FK: host_requests.user_id → users.id)
+        hostRequestJpaRepository.deleteAllInBatch();
+        log.info("[LoadTestDataInitializer] host_requests 테이블 초기화 완료");
+
+        // 2. 기존 users 조회 → Keycloak 사용자 완전 삭제
+        // deleteUser()를 사용해야 동일 이메일로 재생성이 가능함 (disableUser는 이메일 재사용 불가)
+        userJpaRepository.findAll().forEach(user -> {
+            try {
+                keycloakAuthService.deleteUser(user.getKeycloakId());
+            } catch (Exception e) {
+                // Keycloak 상태 불일치(이미 삭제됨 등)는 무시하고 계속 진행
+                log.warn("[LoadTestDataInitializer] Keycloak 삭제 실패 (무시) - keycloakId: {}",
+                    user.getKeycloakId());
+            }
+        });
+
+        // 3. users 전체 삭제 (Keycloak 삭제 완료 후 수행)
+        userJpaRepository.deleteAllInBatch();
+        log.info("[LoadTestDataInitializer] users 테이블 초기화 완료");
+
+        // 4. 부하테스트 계정 n명 생성 (testuser01~25@test.com, 전원 CUSTOMER)
+        userCommandService.seedLoadTestUsers();
+        log.info("[LoadTestDataInitializer] ===== 부하테스트 계정 seed 완료 (n명) =====");
+    }
+}

--- a/src/main/java/com/firstticket/userservice/infrastructure/provider/KeycloakConfig.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/provider/KeycloakConfig.java
@@ -1,14 +1,16 @@
 package com.firstticket.userservice.infrastructure.provider;
 
-import java.net.http.HttpClient;
-import java.time.Duration;
-
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -17,7 +19,10 @@ import org.springframework.web.client.RestClient;
  * 설계 결정 사항
  * - Keycloak 객체는 Singleton 빈으로 등록 → HTTP 연결 풀 재사용, 토큰 캐싱 자동 처리
  * - 매 요청마다 새로 객체를 생성하면 인증 토큰 발급 비용이 반복적으로 발생하므로 빈으로 관리
- * - @EnableConfigurationProperties: KeycloakProperties를 본 Configuration 클래스에서만 활성화
+ * - keycloakRestClient: JDK HttpClient -> Apache HttpClient 5로 교체
+ *   사유: JDK HttpClient는 커넥션 풀 크기를 외부에서 제어할 수 없어
+ *         동시 요청이 몰릴 때 연결 대기 발생. Apache HttpClient 5는
+ *         PoolingHttpClientConnectionManager로 명시적 풀 제어 가능
  */
 @Configuration
 @EnableConfigurationProperties(KeycloakProperties.class) // KeycloakProperties 빈 등록 활성화
@@ -46,20 +51,39 @@ public class KeycloakConfig {
      * Keycloak Token Endpoint 호출용 RestClient 빈
      *
      * 설계 결정 사항
-     * - connectTimeout 3초: 동일 VPC/네트워크 내 Keycloak 서버 연결 지연 임계값
-     * - readTimeout 5초: Keycloak 토큰 발급 처리 시간 + 네트워크 왕복 포함 임계값
-     * - 운영 환경 모니터링 후 조정 가능
+     * - Apache HttpClient 5 + PoolingHttpClientConnectionManager 사용
+     *   → maxTotal(100): 전체 커넥션 풀 크기
+     *   → maxPerRoute(50): Keycloak 단일 호스트에 대한 최대 동시 커넥션
+     *     (부하테스트 최대 vuser 수 이상으로 설정하여 커넥션 대기 제거)
+     *   → 초과 시 즉시 실패로 처리하여 대기 누적 방지
+     * - connectTimeout(3s): 동일 네트워크 내 Keycloak 서버 연결 타임아웃
+     * - responseTimeout(5s): Keycloak 토큰 발급 응답 수신 타임아웃
      */
     @Bean
     public RestClient keycloakRestClient() {
-        // 연결 타임아웃 설정 (서버 연결 수립 단계)
-        HttpClient httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(3))
+        // 커넥션 풀: Keycloak은 단일 호스트이므로 maxPerRoute를 넉넉하게 설정
+        PoolingHttpClientConnectionManager connectionManager =
+            new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(100); // 전체 최대 커넥션 수
+        connectionManager.setDefaultMaxPerRoute(50); // 단일 호스트(Keycloak)당 최대 커넥션 수
+
+        // 요청별 타임아웃 설정
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectionRequestTimeout(Timeout.ofSeconds(1)) // 풀에서 커넥션 획득 대기 상한
+            .setConnectTimeout(Timeout.ofSeconds(3)) // 연결 수립 타임아웃 (Apache HttpClient 5 방식)
+            .setResponseTimeout(Timeout.ofSeconds(5)) // 응답 수신 타임아웃
             .build();
 
-        // 읽기 타임아웃 추가 설정 (응답 수신 단계)
-        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
-        requestFactory.setReadTimeout(Duration.ofSeconds(5));
+        // 커넥션 풀과 타임아웃을 적용한 HttpClient 생성
+        CloseableHttpClient httpClient = HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .setDefaultRequestConfig(requestConfig)
+            .build();
+
+        // Spring RestClient에 Apache HttpClient 5 기반 팩토리 주입
+        // 기존 setConnectTimeout(int) 호출 제거 > 타임아웃은 RequestConfig에서 이미 설정됨
+        HttpComponentsClientHttpRequestFactory requestFactory =
+            new HttpComponentsClientHttpRequestFactory(httpClient);
 
         return RestClient.builder()
             .requestFactory(requestFactory)


### PR DESCRIPTION

## 🌱 설명
- 부하테스트(nGrinder) 중 vuser 25→50 전환 시 발생하던 전면 503 장애의 근본 원인을 찾고 해결
- 조사 결과, 원래 예상했던 **JDK HttpClient 커넥션 풀 미제어** 외에**Resilience4j Bulkhead 기본값(25)** 이 진짜 트리거였음을 확인
- config-repo의 gateway-server관련 설정과 함께 수정했습니다.


## 📌 관련 이슈
- close #43 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [x] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명

### 초기 가설 (이슈 작성 시점)
```
JDK HttpClient 풀 미제어
→ Keycloak 동시 요청 대기 증가
→ CB 조기 개입
→ 전체 503
```
### 실제 원인 (단계별 디버깅 결과)

**1. HikariCP 기본값 (10)** — DB 커넥션 고갈 의심 → `maximum-pool-size: 60`으로 확장  
**2. Zipkin sampling 1.0** — 부하 중 백그라운드 HC 연결 타임아웃이 CPU 경쟁 유발 → `probability: 0`  
**3. CB user-service 오버라이드** — `minimum-number-of-calls: 50, threshold: 70%` 가
   default 완화 설정을 덮어쓰고 있었음 → 인스턴스 오버라이드 제거  
**4. (핵심) Bulkhead 기본값 25** — Gateway DEBUG 로그에서 확인:
```
CircuitBreaker 'user-service' recorded an error:
'BulkheadFullException: Bulkhead 'user-service' is full and does not permit further calls'
Elapsed time: 0 ms
```

Resilience4j Bulkhead의 `maxConcurrentCalls` 기본값이 **25**였습니다.

```
vuser 25 → 동시 25호출 = Bulkhead 한계 정확히 충족 → 전원 통과
vuser 50 → 동시 50호출 = 25개 초과분 0ms 즉시 거부
         → CB sliding window 내 failure-rate 90% 초과
         → CB OPEN → 전체 503
```

파일 | 변경 내용
-- | --
KeycloakConfig.java | JDK HttpClient → Apache HC5, maxTotal=150, maxPerRoute=130
LoadTestDataInitializer.java | 신규: @Profile("load-test") 테스트 계정 시딩
UserCommandService.java | seedLoadTestUsers() 추가 (최대 200개 CUSTOMER)
Dockerfile | 멀티 스테이지 빌드 전환 (builder + runtime 분리)
.dockerignore | 빌드 컨텍스트 최소화


<p>5분 전 구간, 125 vuser, 오류 0건 달성.</p>
<hr>
<h2 data-heading="향후 개선 예정">향후 개선 예정</h2>
<ul>
<li>Redis 토큰 캐싱 — 재로그인 시 Keycloak 호출 생략 (응답시간 162ms → ~10ms 기대)</li>
<li>Keycloak 세션 설정 튜닝</li>
</ul><!--EndFragment-->
</body>
</html>