### PR TITLE
[feat][user-service] Redis Access Token 캐시 도입으로 로그인 API 성능 개선

### DIFF
--- a/src/main/java/com/firstticket/userservice/application/UserCommandService.java
+++ b/src/main/java/com/firstticket/userservice/application/UserCommandService.java
@@ -3,6 +3,7 @@ package com.firstticket.userservice.application;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -30,6 +31,8 @@ import com.firstticket.userservice.domain.service.KeycloakAuthService;
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
 import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult;
 
+import com.firstticket.userservice.domain.service.AccessTokenCache;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,6 +52,7 @@ public class UserCommandService {
     private final KeycloakAuthService keycloakAuthService;
     private final RefreshTokenStore refreshTokenStore;
     private final AccessTokenBlacklist accessTokenBlacklist;
+    private final AccessTokenCache accessTokenCache;
 
     /**
      * 회원가입
@@ -196,9 +200,17 @@ public class UserCommandService {
      * 처리 흐름
      * 1. 이메일로 DB에서 사용자 조회 (없으면 401)
      * 2. 계정 상태 검증 — ACTIVE 이외에는 로그인 거부
-     * 3. Keycloak ROPC 호출 → Access Token + Refresh Token 발급
-     * 4. Refresh Token Redis 저장
-     * 5. TokenResult 반환
+     * 3. AT 캐시 조회 → 히트 시 RefreshTokenStore에서 현재 RT를 조합하여 즉시 반환 (Keycloak 생략)
+     * 4. (캐시 미스) Keycloak ROPC 호출 → Access Token + Refresh Token 발급
+     * 5. Refresh Token Redis 저장
+     * 6. Access Token 캐시 저장 (TTL은 JWT exp 기반으로 구현체가 계산)
+     * 7. TokenResult 반환
+     *
+     * 설계 결정 사항
+     * - AT 캐시에는 Access Token 문자열만 저장합니다. RT는 RefreshTokenStore가 Source of Truth
+     *   Token Rotation 이후에도 RefreshTokenStore는 항상 최신 RT를 보유하므로 stale RT 반환 불가
+     * - 캐시 히트 시 RT가 없는 경우(세션 만료/비정상 상태): AT 캐시를 삭제하고 Keycloak 경로로 폴백
+     *   이론상 AT TTL(30분) < RT TTL(7일)이므로 정상 운영에서는 발생하지 않음
      */
     @Transactional(readOnly = true)
     public TokenResult login(LoginCommand command) {
@@ -216,13 +228,35 @@ public class UserCommandService {
             throw new UserException(UserErrorCode.INVALID_CREDENTIALS);
         }
 
-        // 3. Keycloak Token Endpoint 호출
+        // 3. AT 캐시 조회 - 동일 사용자의 재로그인 시 Keycloak ROPC 호출 생략 (성능 개선 핵심)
+        Optional<String> cachedAt = accessTokenCache.find(command.email());
+        if (cachedAt.isPresent()) {
+            // AT 캐시 hit: RefreshTokenStore에서 현재 RT를 조합하여 반환
+            // RefreshTokenStore는 Token Rotation을 통해 항상 최신 RT를 유지합니다.
+            Optional<String> currentRt = refreshTokenStore.find(user.getId());
+            if (currentRt.isPresent()) {
+                // AT(캐시) + RT(최신) 조합 반환 — Keycloak 호출 없음 (~5ms)
+                log.info("[login] AT 캐시 히트 - Keycloak 호출 생략, userId: {}", mask(user.getId()));
+                return new TokenResult(cachedAt.get(), currentRt.get());
+            }
+            // RT가 없는 비정상 상태: stale 캐시 제거 후 Keycloak 경로로 폴백
+            // (AT TTL=30분 < RT TTL=7일 이므로 정상 운영에서는 발생하지 않는 방어 코드)
+            log.info("[login] AT 캐시 히트이나 RT 없음 — 캐시 무효화 후 Keycloak 재호출, userId: {}",
+                mask(user.getId()));
+            accessTokenCache.delete(command.email());
+        }
+
+        // 4. 캐시 miss - 기존과 동일하게 Keycloak Token Endpoint 호출
         TokenResult tokenResult = keycloakAuthService.login(command.email(), command.password());
 
-        // 4. Refresh Token Redis 저장
+        // 5. Refresh Token Redis 저장
         refreshTokenStore.save(user.getId(), tokenResult.refreshToken());
 
-        // 5. AccessToken, RefreshToken 반환
+        // 6. Access Token 캐시 저장
+        accessTokenCache.save(command.email(), tokenResult.accessToken());
+
+        log.info("[login] 캐시 미스 - Keycloak 호출 후 캐시 저장, userId: {}", mask(user.getId()));
+        // 7. AT + RT 반환
         return tokenResult;
     }
 
@@ -231,32 +265,38 @@ public class UserCommandService {
      * 처리 흐름
      * 1. Gateway X-User-Id(keycloakId)로 사용자 조회
      * 2. Redis에서 Refresh Token 삭제 → 재발급 경로 차단
-     * 3. Access Token을 blacklist에 등록 -> 잔여 TTL 동안 즉시 무효화
+     * 3. Access Token을 blacklist에 등록 → 잔여 TTL 동안 즉시 무효화
+     * 4. AT 캐시 무효화 → 로그아웃 후 stale 토큰이 재반환되는 경로 차단
      *
      * 설계 결정 사항
-     * - jti와 tokenExpEpoch는 Gateway AuthorizationHeaderFilter가 JWT에서 추출해 헤더로 주입
+     * - jti 및 tokenExpEpoch는 Gateway AuthorizationHeaderFilter가 JWT에서 추출해 헤더로 주입
      *   user-service는 JWT 파싱 없이 헤더 값만 사용 (관심사 분리)
      * - tokenExpEpoch - now <= 0이면 이미 만료된 토큰 → blacklist 저장 생략 (AccessTokenBlacklistImpl 내부 처리)
      * - blacklist 조회는 Gateway가 Redis를 직접 읽으므로 서비스 간 호출 없음
+     * - AT 캐시 무효화는 blacklist 등록과 함께 이중으로 수행 → 재로그인 시 stale 토큰 반환 방지
      */
     @Transactional(readOnly = true)
     public void logout(LogoutCommand command) {
-        // 1. keycloakId로 사용자 조회
+        // 1. user.keycloakId로 사용자 조회
         User user = userRepository.findByKeycloakId(command.keycloakId())
             .orElseThrow(() -> {
                 log.warn("[logout] 사용자 조회 실패 - keycloakId: {}", mask(command.keycloakId()));
                 return new UserException(UserErrorCode.USER_NOT_FOUND);
             });
 
-        // 2. Refresh Token 삭제 → 재발급 경로 차단
+        // 2. Refresh Token 삭제
         refreshTokenStore.delete(user.getId());
         log.info("[logout] Refresh Token 삭제 완료 - userId: {}", mask(user.getId()));
 
         // 3. Access Token blacklist 등록
-        // TTL = 토큰 만료 시각(epoch초) - 현재 시각(epoch초)
+        // TTL = 토큰 만료 시각 - 현재 시각
         long ttlSeconds = command.tokenExpEpoch() - Instant.now().getEpochSecond();
         accessTokenBlacklist.add(command.jti(), ttlSeconds);
         log.info("[logout] Access Token blacklist 등록 완료 - userId: {}, ttl: {}s", mask(user.getId()), ttlSeconds);
+
+        // 4. AT 캐시 무효화
+        accessTokenCache.delete(user.getEmail());
+        log.info("[logout] AT 캐시 무효화 완료 - userId: {}", mask(user.getId()));
     }
 
     /**
@@ -400,14 +440,14 @@ public class UserCommandService {
      * 2. DB Soft Delete (status=DELETED, deletedBy=본인 DB PK)
      * 3. Keycloak 계정 비활성화 (로그인 차단)
      * 4. Redis Refresh Token 즉시 삭제 (현재 세션 무효화)
-     *
+     * 5. AT 캐시 무효화 (탈퇴 사용자 토큰 즉시 무효화)
      */
     //TODO:DB 커밋 성공 후 Keycloak 호출 실패 시 불일치 발생 가능 -> MVP 구현 후 @TransactionalEventListener(AFTER_COMMIT) 또는 Outbox 패턴 적용 예정
     @Transactional
     public void withdraw(String keycloakId) {
         Objects.requireNonNull(keycloakId, "keycloakId는 null일 수 없습니다.");
 
-        // 1. keycloakId로 사용자 조회
+        // 1. keycloakId로 사용자 조회 (이메일 획득을 위해 필요)
         User user = userRepository.findByKeycloakId(keycloakId)
             .orElseThrow(() -> {
                 log.warn("[withdraw] 존재하지 않는 사용자 - keycloakId: {}", mask(keycloakId));
@@ -423,6 +463,9 @@ public class UserCommandService {
 
         // 4. Redis Refresh Token 즉시 삭제 - 현재 세션 즉시 무효화
         refreshTokenStore.delete(user.getId());
+
+        // 5. AT 캐시 무효화 - 탈퇴 사용자의 토큰이 재로그인 경로에서 반환되지 않도록 즉시 제거
+        accessTokenCache.delete(user.getEmail());
 
         log.info("[withdraw] 회원탈퇴 완료 - userId: {}", mask(user.getId()));
     }
@@ -496,6 +539,9 @@ public class UserCommandService {
         // 5. Keycloak Admin API로 비밀번호 변경
         // 실패 시 KEYCLOAK_PASSWORD_CHANGE_FAILED (500) 발생
         keycloakAuthService.changePassword(user.getKeycloakId(), command.newPassword());
+
+        // 6. AT 캐시 무효화 - 비밀번호 변경 후 구 토큰이 캐시에서 반환되는 경로 차단
+        accessTokenCache.delete(user.getEmail());
 
         log.info("[changePassword] 비밀번호 변경 완료 - userId: {}", mask(user.getId()));
     }

--- a/src/main/java/com/firstticket/userservice/domain/service/AccessTokenCache.java
+++ b/src/main/java/com/firstticket/userservice/domain/service/AccessTokenCache.java
@@ -1,0 +1,34 @@
+package com.firstticket.userservice.domain.service;
+
+import java.util.Optional;
+
+/**
+ * Access Token 캐시 저장소 Port
+ *
+ * 설계 결정 사항
+ * - domain 계층에 인터페이스를 선언함으로 infrastructure(Redis) 직접 의존을 차단
+ *   (RefreshTokenStore, AccessTokenBlacklist 패턴과 동일 원칙)
+ * - 캐시 키 생성(SHA-256), TTL 계산(JWT exp 파싱)은 모두 구현체에서 담당
+ * - 재로그인 시 Keycloak ROPC 호출(~135ms)을 생략하고 Redis 조회(~5ms)로 대체하는 성능 최적화가 목적
+ */
+public interface AccessTokenCache {
+
+    /**
+     * Access Token을 이메일 기반 캐시 키로 저장
+     * TTL은 구현체가 JWT의 exp 클레임을 파싱하여 계산
+     */
+    void save(String email, String accessToken);
+
+    /**
+     * 이메일로 캐시된 Access Token을 조회
+     * 캐시가 없거나 TTL이 만료된 경우 Optional.empty()를 반환
+     */
+    Optional<String> find(String email);
+
+    /**
+     * 이메일에 해당하는 Access Token 캐시를 삭제
+     * 로그아웃 / 비밀번호 변경 / 회원탈퇴 시 stale 토큰 반환을 방지하기 위해 호출
+     * @param email 사용자 이메일
+     */
+    void delete(String email);
+}

--- a/src/main/java/com/firstticket/userservice/infrastructure/redis/AccessTokenCacheImpl.java
+++ b/src/main/java/com/firstticket/userservice/infrastructure/redis/AccessTokenCacheImpl.java
@@ -1,0 +1,156 @@
+package com.firstticket.userservice.infrastructure.redis;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstticket.userservice.domain.service.AccessTokenCache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+// domain/service/AccessTokenCache Port의 Redis 구현체
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessTokenCacheImpl implements AccessTokenCache {
+
+    private final StringRedisTemplate redisTemplate;
+    // JWT payload 파싱에 사용
+    private final ObjectMapper objectMapper;
+    private static final String KEY_PREFIX = "at-cache:";
+    private static final long DEFAULT_TTL_SECONDS = 1800L;
+
+    @Override
+    public void save(String email, String accessToken) {
+        // JWT exp 기반으로 남은 유효 시간을 TTL로 계산
+        long ttlSeconds = extractRemainingTtl(accessToken);
+
+        // 이미 만료된 토큰을 캐시에 넣으면 즉시 redis에서 사라지거나 오류 발생 → 저장 자체를 생략
+        if (ttlSeconds <= 0) {
+            log.warn("[AT cache] 이미 만료된 Access Token - 캐시 저장 생략, email: {}", abbreviated(email));
+            return;
+        }
+
+        // SET at-cache:{SHA-256(email)} "{accessToken}" EX {ttlSeconds}
+        redisTemplate.opsForValue().set(
+            buildKey(email),  // PII 보호를 위한 해시 키
+            accessToken,      // AT 문자열 원문 (Base64 JWT)
+            ttlSeconds,
+            TimeUnit.SECONDS
+        );
+
+        log.debug("[AT cache] 캐시 저장 완료 - email: {}, ttl: {}s", abbreviated(email), ttlSeconds);
+    }
+
+    @Override
+    public Optional<String> find(String email) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(buildKey(email)));
+    }
+
+    /**
+     * 이메일에 해당하는 AT 캐시를 삭제
+     * 로그아웃 / 비밀번호 변경 / 회원탈퇴 시 호출하여 stale 토큰 반환을 방지
+     */
+    @Override
+    public void delete(String email) {
+        // DEL at-cache:{SHA-256(email)}
+        redisTemplate.delete(buildKey(email));
+        log.debug("[AT cache] 캐시 삭제 완료 - email: {}", abbreviated(email));
+    }
+
+    /**
+     * Redis 키 생성
+     * email을 소문자로 정규화한 뒤 SHA-256 해시하여 PII 보호
+     */
+    private String buildKey(String email) {
+        return KEY_PREFIX + sha256(email.toLowerCase(Locale.ROOT));
+    }
+        private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            // 문자열을 UTF-8 바이트로 변환 후 해시
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+
+            // byte 배열을 2자리 소문자 16진수 문자열로 변환 (총 64자)
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256은 Java SE 명세상 필수 지원 알고리즘이므로 이 분기는 실행되지 않음
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", e);
+        }
+    }
+
+    /**
+     * Access Token JWT payload에서 exp(만료 epoch초)를 읽어 현재 시각과의 차이를 반환
+     * KeycloakAuthServiceImpl.extractSubject()와 동일한 Base64URL 디코딩 방식을 사용
+     *
+     * @return 남은 유효 시간(초). 파싱 실패 시 DEFAULT_TTL_SECONDS, 이미 만료 시 <=0
+     */
+    private long extractRemainingTtl(String accessToken) {
+        try {
+            // JWT 구조: {header}.{payload}.{signature} — 점(.)으로 3분할
+            String[] parts = accessToken.split("\\.");
+            if (parts.length != 3) {
+                // 잘못된 JWT 형식 — 기본 TTL로 폴백
+                log.warn("[AT cache] JWT 형식 오류 - 기본 TTL {}s 사용", DEFAULT_TTL_SECONDS);
+                return DEFAULT_TTL_SECONDS;
+            }
+
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(addPadding(parts[1]));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> claims = objectMapper.readValue(payloadBytes, Map.class);
+
+            Object exp = claims.get("exp");
+            if (exp == null) {
+                log.warn("[AT cache] exp 클레임 없음 - 기본 TTL {}s 사용", DEFAULT_TTL_SECONDS);
+                return DEFAULT_TTL_SECONDS;
+            }
+
+            long expEpoch = ((Number) exp).longValue();
+            return expEpoch - Instant.now().getEpochSecond();
+
+        } catch (Exception e) {
+            // Base64 디코딩 실패, JSON 파싱 실패 등 → 기본 TTL로 fallback
+            log.warn("[AT cache] exp 클레임 추출 실패, 기본 TTL {}s 사용: {}", DEFAULT_TTL_SECONDS, e.getMessage());
+            return DEFAULT_TTL_SECONDS;
+        }
+    }
+
+    /**
+     * Base64URL 인코딩 문자열에 누락된 패딩(=)을 복원합니다.
+     * JWT는 패딩 없이 인코딩하지만 Java의 Base64.getUrlDecoder()는 패딩을 요구
+     */
+    private String addPadding(String base64Url) {
+        int remainder = base64Url.length() % 4;
+        if (remainder == 2) return base64Url + "=="; // 2글자 부족
+        if (remainder == 3) return base64Url + "=";  // 1글자 부족
+        return base64Url;
+    }
+
+    /**
+     * 로그에 이메일 원문이 노출되지 않도록 앞 3자리만 표시
+     * ex) "user@example.com" → "use***"
+     */
+    private String abbreviated(String email) {
+        if (email == null || email.length() <= 3) return "***";
+        return email.substring(0, 3) + "***";
+    }
+}

--- a/src/test/java/com/firstticket/userservice/application/UserCommandServiceTest.java
+++ b/src/test/java/com/firstticket/userservice/application/UserCommandServiceTest.java
@@ -1,5 +1,22 @@
 package com.firstticket.userservice.application;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.firstticket.userservice.application.dto.command.ChangePasswordCommand;
 import com.firstticket.userservice.application.dto.command.LoginCommand;
 import com.firstticket.userservice.application.dto.command.LogoutCommand;
@@ -10,37 +27,15 @@ import com.firstticket.userservice.application.dto.result.TokenResult;
 import com.firstticket.userservice.application.dto.result.UserResult;
 import com.firstticket.userservice.domain.Email;
 import com.firstticket.userservice.domain.User;
-import com.firstticket.userservice.domain.UserRole;
 import com.firstticket.userservice.domain.UserRepository;
+import com.firstticket.userservice.domain.UserRole;
 import com.firstticket.userservice.domain.exception.UserErrorCode;
 import com.firstticket.userservice.domain.exception.UserException;
 import com.firstticket.userservice.domain.service.AccessTokenBlacklist;
+import com.firstticket.userservice.domain.service.AccessTokenCache;
 import com.firstticket.userservice.domain.service.KeycloakAuthService;
 import com.firstticket.userservice.domain.service.RefreshTokenStore;
 import com.firstticket.userservice.domain.service.RefreshTokenStore.RotateResult;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Instant;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.mockito.InOrder;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * UserCommandService 단위 테스트
@@ -68,6 +63,9 @@ class UserCommandServiceTest {
 
     @Mock
     private AccessTokenBlacklist accessTokenBlacklist;
+
+    @Mock
+    private AccessTokenCache accessTokenCache;
 
     // keycloakId는 Keycloak이 발급하는 UUID 문자열
     private final String KEYCLOAK_ID = UUID.randomUUID().toString();
@@ -140,6 +138,8 @@ class UserCommandServiceTest {
             TokenResult tokenResult = new TokenResult("access-token", "refresh-token");
 
             when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+            // 캐시 미스 시나리오: 저장된 AT 없음 → Keycloak 호출 경로 진입
+            when(accessTokenCache.find(anyString())).thenReturn(Optional.empty());
             when(keycloakAuthService.login(anyString(), anyString())).thenReturn(tokenResult);
 
             // when
@@ -149,8 +149,8 @@ class UserCommandServiceTest {
             assertThat(result.accessToken()).isEqualTo("access-token");
             assertThat(result.refreshToken()).isEqualTo("refresh-token");
 
-            // Refresh Token을 Redis에 저장했는지 검증
-            verify(refreshTokenStore).save(any(), anyString());
+            verify(refreshTokenStore).save(any(), anyString()); // RT Redis 저장
+            verify(accessTokenCache).save(anyString(), anyString()); // AT 캐시 저장
         }
 
         @Test
@@ -228,8 +228,10 @@ class UserCommandServiceTest {
 
             // then — Refresh Token 삭제 + Access Token blacklist 등록 순서로 검증
             InOrder inOrder = inOrder(refreshTokenStore, accessTokenBlacklist);
-            inOrder.verify(refreshTokenStore).delete(any());           // Refresh Token 삭제
-            inOrder.verify(accessTokenBlacklist).add(anyString(), anyLong()); // blacklist 등록
+            inOrder.verify(refreshTokenStore).delete(any());
+            inOrder.verify(accessTokenBlacklist).add(anyString(), anyLong());
+            // AT 캐시 무효화 — 로그아웃 후 stale 토큰 재반환 방지
+            verify(accessTokenCache).delete(anyString());
         }
 
         @Test
@@ -466,9 +468,10 @@ class UserCommandServiceTest {
             // when
             userCommandService.withdraw(KEYCLOAK_ID);
 
-            // then - 3단계 처리 모두 호출 검증
+            // then — 3단계 처리 모두 호출 검증
             verify(keycloakAuthService).disableUser(KEYCLOAK_ID); // Keycloak 비활성화
-            verify(refreshTokenStore).delete(any());               // Redis 토큰 삭제
+            verify(refreshTokenStore).delete(any());               // Redis RT 삭제
+            verify(accessTokenCache).delete(anyString());          // AT 캐시 무효화
         }
 
         @Test
@@ -491,7 +494,7 @@ class UserCommandServiceTest {
 
         // 테스트 전용 비밀번호 픽스처 (Password VO 최소 요건인 8자 이상 충족)
         private static final String CURRENT_PW = "CurrentPass1!";
-        private static final String NEW_PW     = "NewPassword1!";
+        private static final String NEW_PW = "NewPassword1!";
 
         @Test
         @DisplayName("정상 변경 시 Keycloak 현재 비밀번호 검증 후 새 비밀번호로 변경한다")
@@ -501,17 +504,18 @@ class UserCommandServiceTest {
             ChangePasswordCommand command = new ChangePasswordCommand(CURRENT_PW, NEW_PW);
 
             when(userRepository.findByKeycloakId(KEYCLOAK_ID)).thenReturn(Optional.of(user));
-            // login()은 현재 비밀번호 검증 목적으로 호출 - 반환된 토큰은 서비스에서 버림
             when(keycloakAuthService.login(anyString(), anyString()))
                 .thenReturn(new TokenResult("access-token", "refresh-token"));
 
             // when
             userCommandService.changePassword(KEYCLOAK_ID, command);
 
-            // 현재 비밀번호 검증 후 변경 - 흐름 순서를 테스트로 명시
+            // then — 현재 비밀번호 검증 후 변경 흐름 순서 검증
             InOrder inOrder = inOrder(keycloakAuthService);
             inOrder.verify(keycloakAuthService).login(anyString(), anyString());
             inOrder.verify(keycloakAuthService).changePassword(KEYCLOAK_ID, NEW_PW);
+            // AT 캐시 무효화 — 비밀번호 변경 후 구 토큰 재사용 방지
+            verify(accessTokenCache).delete(anyString());
         }
 
         @Test


### PR DESCRIPTION
## 🌱 설명
- `AccessTokenCache` Port 인터페이스 신규 추가 (Hexagonal Architecture)
- `AccessTokenCacheImpl`: Redis `at-cache:{SHA-256(lower(email))}` 키, JWT exp 기반 TTL 동적 계산
- `UserCommandService.login()`: 캐시 HIT 시 Keycloak ROPC 호출 생략, AT + 최신 RT 조합 반환
- 캐시 무효화 트리거: `logout()` / `changePassword()` / `withdraw()`
- 코드 수정에 맟춰 테스트 코드 수정

## 📌 관련 이슈
- close #46 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명




지표 | 개선 전 | 개선 후 | 변화
-- | -- | -- | --
평균 TPS | 175 | 1,568 | +796%
평균 응답시간 | 135ms | 63.67ms | -53%
안정 vuser 한계 | 25 | 125+ | +400%
에러 | 0 | 0 | -


## 설계 결정

**AT만 캐시, RT는 RefreshTokenStore가 Source of Truth**
- 캐시 HIT 시 AT(캐시) + RT(RefreshTokenStore.find()) 조합 반환
- Token Rotation 이후에도 항상 최신 RT를 반환하므로 stale RT 문제 방지

**SHA-256(lower(email)) 해시 키**
- Redis 유출 시 이메일 원문 노출 방지 (PII 보호)
- DB의 `LOWER(email)` 함수 인덱스와 동일 기준 적용

**TTL = JWT exp 클레임 동적 계산**
- Keycloak AT 만료 설정 변경 시 자동 동기화, 하드코딩 없음
- 파싱 실패 시 1800초(30분) 안전 기본값 사용