### PR TITLE
CD 정상 배포 테스트 3차 (#53)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,12 +14,26 @@ spring:
       - "optional:configserver:"             # URL 없이 Eureka 디스커버리로 Config Server 탐색
 
   cloud:
+    # ECS Fargate에서 Eureka에 자기 IP를 ECS 메타데이터 IP(169.254.172.2)가 아닌 VPC 내부 IP(172.31.x.x)로 등록되게 하기 위한 설정.
+    # InetUtils가 IP 선택 시점이 Config Server 받기 전이라
+    inetutils:
+      preferred-networks:
+        - 10\.
+        - 172\.
+        - 192\.168\.
+        -
     config:
       username: ${CONFIG_SERVER_USERNAME}  # Config Server Basic Auth
       password: ${CONFIG_SERVER_PASSWORD}
       discovery:
         enabled: true
         service-id: config-server
+      fail-fast: true # Config Server 연결 실패시 즉시 종료 (무한 대기 방지)
+      retry: # 연결 재시도 설정 (기동 초기 레이스 컨디션 대응)
+        max-attempts: 20
+        initial-interval: 2000
+        max-interval: 5000
+        multiplier: 1.2
 
 eureka:
   instance:


### PR DESCRIPTION
* [chore][user-service] user-service 프로젝트 기초 세팅 (#2)

* chore: 프로젝트 기초 세팅
- build.gradle 적용
- common 패키지
- config server 연결

* chore: user-service 기초 세팅

- application.yaml 작성
- build.gradle 작성
- docker-compose.yml 작성

* chore: coderabbit 권고사항 수정

- .editorconfig 추가
- test 환경용 설정 추가

* fix: 설정파일 분리 -applicaion-local.yaml 생성
-.env.example 수정 (불필요한 변수 제거)

* [feat][user-service] 도메인 모델 및 영속성 레이어 구성 (#4)

* feat: User/HostRequest 도메인 ENUM, VO, ErrorCode 정의
- UserStatus - 상태 전이 규칙을 Enum에서 검증
- HostRequestStatus - PENDING → APPROVED/REJECTED 단방향 전이
- Email - 정규식 형식 검증 포함, 정적 팩토리 메서드로만 생성 가능
- Password - Keycloak 전달 전 최소 형식 검증, toString 마스킹 처리
- UserErrorCode - common 모듈의 ErrorCode 인터페이스 구현, 에러코드 체계 정의

* feat: User/HostRequest Aggregate Entity 및 Repository 인터페이스 정의

- User: lock/unlock/softDelete/changeRole 비즈니스 메서드, create() 정적 팩토리 메서드
- HostRequest: approve/reject 메서드, PENDING 중복은 Application 계층에서 제어
- UserRepository/HostRequestRepository: Spring Data 미의존 순수 Java 도메인 인터페이스
- UserQueryRepository: CQRS Read Side 분리, Pageable 기반 ADMIN 검색 지원
- UserSearchSpec/UserSummaryData: null = 조건 미적용, 민감정보 제외 Projection

* feat: users, host_requests 테이블 Flyway 마이그레이션 스크립트 추가

- V1: users 테이블 생성, BaseUserEntity Auditor 컬럼 포함
- V2: host_requests 테이블 생성, users.id FK 참조 (V1 이후 실행순서 보장)
- (user_id, status) 복합 인덱스 추가로 PENDING 중복 조회 성능 확보
- ddl-auto: validate 기준으로 Entity 컬럼명과 일치

* feat: JPA 영속성 레이어 구현체 및 SecurityAuditorAware 추가

- UserRepositoryImpl/HostRequestRepositoryImpl: Adapter 패턴으로 도메인 인터페이스 구현
- UserQueryRepositoryImpl: Querydsl BooleanBuilder 동적 조건 검색, PageImpl 반환
- HostRequestJpaRepository: findByUserIdAndStatus로 status 조건 명시적 조회
- SecurityAuditorAware: X-User-Id 헤더 → JPA createdBy/updatedBy 자동 주입

* feat: coderabbit 권고사항 반영

* fix: 팀컨벤션에 맞게 수정

- errorcode 형식에서 code 제거
- create @AllArgsConstructor 사용
- AuditorAware는 common으로 이관 예정

* [feat][user-service] 회원가입 API 구현 (#6)

* fix : 수정사항 반영

- BusinessException -> UserException 생성 및 적용
- Aggregate Root Entity에 @AllArgsConstructor(access = AccessLevel.PRIVATE) 적용
- users 테이블 email 컬럼 UNIQUE 조건을 별도로 설정 (대소문자 포함하도록)

* feat(user-service): U-01 회원가입 API 구현

- AuthController POST /api/v1/auth/signup 엔드포인트 추가
- UserCommandService - 회원가입 비즈니스 로직 구현
- KeycloakAuthService Port/Adapter 분리 (헥사고날 아키텍처)
- KeycloakProperties - @ConfigurationProperties 바인딩
- Email, Password VO 형식 검증
- SignupCommand, UserResult, UserResponse DTO 계층 분리
- User.initCreatedBy(UUID) 추가 - keycloakId를 created_by로 직접 주입
- UserCommandService.signup()에서 저장 전 initCreatedBy 호출
- user-service/docker-compose.yml Redis, Keycloak 제거 (infra 공유 인프라로 테스트 환경 설정 - 포트 충돌 방지)

* fix: coderabbit 권고사항 반영

- 예외검증 추가
- 소문자 정규화 추가

* fix: coderabbit 권고사항 반영

* [feat][user-service] 로그인 API 구현 (#8)

* feat: 로그인 API 구현

* refactor: 로그인 관련 설정 추가

* feat: coderabbit 권고사항 수정

* feat: nitpick 사항 수정

- .gitignore 주석 수정
- 컨트롤러 javadoc 추가
- 주석에서 인프라 세부사항 제거
- keyclock 서버 5xx 세분화 처리 추가

* feat: coderabbit 권고사항 수정

- 400, 401 예외 분리해서 처리

* feat: 로그아웃 / 토큰 재발급 api 구현 (#10)

* feat: 로그아웃 / 토큰 재발급 api 구현

- 로그아웃시 redis에서 Refresh Token 삭제
- 토큰 재발급시 Token Rotation 적용
- 저장 토큰 불일치시 세션 즉시 무효화

* chore: .env.example 수정

* fix : coderabbit 권고사항 반영
- 토큰 원자성 보장하도록 수정
- yml 설정 config-repo로 이관

* [feat][user-service] 사용자 내 정보 조회 api 구현 (#13)

* feat: 사용자 내정보 조회 api 구현

- CQRS 정책으로 command와 query 분리
- common모듈 0.0.4 버전으로 업데이트

* fix: coderabbit 리뷰 반영

- keycloak role 부여 실패시 보상처리 적용
- 로깅 마스킹 추가

* [feat][user-service] ADMIN 사용자 관리 API 구현 (#14)

* feat: 사용자 내정보 조회 api 구현

- CQRS 정책으로 command와 query 분리
- common모듈 0.0.4 버전으로 업데이트

* fix: coderabbit 리뷰 반영

- keycloak role 부여 실패시 보상처리 적용
- 로깅 마스킹 추가

* feat: ADMIN 사용자 관리 API 구현 / Keycloak 연동

- AdminController: 사용자 목록/단건 조회, 탈퇴 처리, 역할 변경 엔드포인트 추가
- UserCommandService: deleteUser/changeRole에 Keycloak 비활성화·역할 변경 연동
- KeycloakAuthService: disableUser(), changeUserRole() 포트 메서드 추가
- KeycloakAuthServiceImpl: Keycloak Admin Client 기반 두 메서드 구현
- UserErrorCode: KEYCLOAK_USER_DISABLE_FAILED 에러코드 추가
- UserSearchRequest, AdminUserResponse, ChangeRoleRequest DTO 추가

* fix: coderabbit 리뷰 내용 반영

* [feat][user-service] HOST 신청 관리 API 구현 (#16)

* feat: HOST 신청 관리 API 구현

- POST /api/v1/users/me/host-requests : CUSTOMER 전용 HOST 신청
- GET  /api/v1/admin/host-requests    : PENDING 목록 조회 (페이지네이션)
- PATCH /api/v1/admin/host-requests/{requestId} : 승인/거절 처리

- HostRequestStatus 상태 전이 규칙을 Enum 내부에서 캡슐화
- PENDING 중복 신청 방지: Application 체크 + DB Partial Unique Index 이중 방어
- 승인 시 User.changeRole(HOST) + Keycloak role 동기화 연계 처리
- CUSTOMER 역할 아닌 사용자 신청 시 403 반환
- X-User-Id(keycloakId)로 User 조회 시 findByKeycloakId() 사용
- UUID 로그 마스킹 적용

* fix: coderabbit 권고사항 반영

- DataIntegrityViolationException 처리
- Objects.requireNonNull() 방어
- 도메인 포트에 Spring Data 타입 오염 방지

* fix: coderabbit 권고사항 반영 002

* [feat][user-service] 내 정보 수정 / 회원 탈퇴 API 구현 (#18)

* feat: 내 정보 수정 / 회원 탈퇴 API 구현

- PATCH /api/v1/users/me: username 변경 (DELETED 상태 차단, LOCKED 허용)
- DELETE /api/v1/users/me: Soft Delete + Keycloak 비활성화 + Redis 세션 무효화
- UpdateProfileCommand / UpdateProfileRequest DTO 추가
- UserSuccessCode: PROFILE_UPDATED, WITHDRAW_SUCCESS 추가

* feat: coderabbit 권고사항 반영

- Outbox 패턴은 MVP 개발 후 추가 고려

* [chore][user-service] REST Docs 빌드 환경 설정 (#20)

* chore: REST Docs 빌드 환경 설정

* chore: REST Docs 빌드 환경 설정

* [test][user-service] Domain 단위 테스트 작성 (#22)

* feat: Domain 단위 테스트 작성
- 유효값 검증
- null, 빈값 등 VO 불변식
- 상태 전이 규칙 검증
- 엔티티 비즈니스 메서드

* fix : PasswordTest - 공백 입력 예외 테스트 추가

* test : application 서비스 단위 테스트 작성 (#26)

- 외부 api Mock 테스트
- 예외 케이스 검증

* [test][user-service] Controller 테스트 작성 (#27)

* test : Controller 테스트 작성

- API 요청 / 응답 스펙 검증 및 문서화
- 예외 케이스 검증

* test : Jacoco 테스트 커버리지 검증도구 추가

* test : code래빗 권고사항 반영

* test : code래빗 권고사항 반영

* [docs][user-service] asciidoc 작성 (#28)

* docs: asciidoc 작성

* docs: coderabbit 리뷰내용 반영

* [feat][user-service] http client 테스트 추가 (#30)

* feat: http client 테스트 추가

- db user_schema로 분리
- 로컬테스트시 db초기화 및 테스트 데이터 삽입 로직 구현
- http-client 테스트 작성 및 사용가이드

* feat: http client 테스트 추가

- 가이드 수정

* feat: http client 테스트 추가

- 오탈자 수정

* chore: dockerfile 작성 (#32)

- dockerfile
- dockerignore
- 기타 수정

* chore: CI 워크플로우 추가 (#34)

* chore: 모니터링 의존성 추가 및 yml 설정 변경 (#36)

* chore: 도커 설정 수정 (#38)

- 환경변수 추가

* feat: 비밀번호 변경 API 구현 (POST /api/v1/users/me/password) (#40)

- Keycloak ROPC로 현재 비밀번호 검증 후 Admin API로 신규 비밀번호 변경
- 검증용 토큰을 RFC 7009 Token Revocation으로 즉시 폐기 (고아 세션 방지)
- WRONG_CURRENT_PASSWORD 응답 코드 401 → 422 Unprocessable Entity 수정 (api-response.md 컨벤션: 도메인 규칙 위반은 422)
- ChangePasswordRequest/Command compact constructor 추가 (null 방어)
- catch 블록에 userId/errorCode 컨텍스트 로그 추가 및 RuntimeException 분리 처리
- UserCommandService/UserController 단위 테스트 11건 추가

* feat: Access Token Blacklist 구현으로 로그아웃 즉시 무효화 (#42)

- AccessTokenBlacklist 포트 + Redis 구현체 추가 key: blacklist:{jti}, TTL = 토큰 잔여 만료 시간
- LogoutCommand에 jti, tokenExpEpoch 필드 추가
- logout() 처리 순서: Refresh Token 삭제 → Access Token blacklist 등록
- AuthController.logout()에 X-Jti, X-Token-Exp 헤더 수신 추가 (Gateway AuthorizationHeaderFilter가 JWT 클레임에서 추출하여 주입)
- AccessTokenBlacklistImplTest 5건, Logout 테스트 전면 수정

* refactor: replace JDK HttpClient with Apache HC5 and add load test infrastructure (#44)

- KeycloakConfig: JDK HttpClient → Apache HC5 (PoolingHttpClientConnectionManager, maxTotal=150, maxPerRoute=130, connectionRequestTimeout=3s)
- LoadTestDataInitializer: @Profile("load-test") 환경 전용 테스트 계정 시딩 컴포넌트 추가
- UserCommandService: seedLoadTestUsers() — 최대 200개 CUSTOMER 계정 동적 생성
- Dockerfile: 단일 JAR 복사 방식 → 멀티 스테이지 빌드로 전환 (builder/runtime 분리)
- .dockerignore: 빌드 컨텍스트 최소화 (.gradle, build, .git 등 제외)

* [feat][user-service] Redis Access Token 캐시 도입으로 로그인 API 성능 개선 (#47)

* feat(user-service): Redis AT 캐시 도입으로 로그인 API 성능 개선

Keycloak ROPC 반복 호출을 Redis 캐시로 대체하여 로그인 처리량을
175 TPS에서 1,568 TPS로 향상 (+796%).

- AccessTokenCache Port 인터페이스 신규 추가
- AccessTokenCacheImpl: at-cache:{SHA-256(lower(email))} 키, JWT exp 기반 TTL 동적 계산
- UserCommandService.login(): 캐시 HIT 시 Keycloak ROPC 생략, AT + 최신 RT 조합 반환
- 캐시 무효화 트리거 3곳: logout / changePassword / withdraw

* test: 로그인 at 캐싱 적용에 따른 테스트코드 조정

* chore: CI/CD 통합 워크플로우 추가 및 Dockerfile 보안 개선 (#49)

- ci.yml 제거 후 deploy.yml로 CI/CD 통합
- build-and-test Job: 모든 PR·push에서 테스트 → asciidoctor → bootJar 실행
- push-to-ecr Job: main 브랜치 push 시 ECR 이미지 푸시 및 ECS 배포 수행
- Dockerfile 토큰 전달 방식을 --build-arg에서 Docker BuildKit secret으로 교체 (이미지 레이어 노출 방지)
- Dockerfile 멀티스테이지 빌드 구조 명확화 (JDK builder → JRE runtime)

* - 배포 설정을 팀 공통 사항에 맞게 수정 (#52)

## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 예) 회원가입 API 엔드포인트 추가


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) close #12


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [ ] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->