### PR TITLE
[chore][user-service] Dockerfile 런타임 환경 개선 및 배포 설정 보완

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,4 @@
 # first-ticket / user-service CI/CD 통합 워크플로우
-# 트리거: main·dev 브랜치 PR 또는 push 시에 실행
-# 단계 1 - build-and-test (모든 이벤트)
-# 단계 2 - push-to-ecr (main push 시)
-
 name: CI/CD - Build, Test, and Deploy
 
 on:
@@ -65,10 +61,9 @@ jobs:
           retention-days: 7
 
   # Job 2: ECR 이미지 푸시 + ECS 배포
-  # 조건: main 브랜치에 push 이벤트일 때만 실행
   push-to-ecr:
     needs: build-and-test # build-and-test 성공 후 실행
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,46 @@
-# user-service 배포용 Dockerfile
-# Stage 1: 빌드
-FROM eclipse-temurin:21-jdk-alpine AS builder
+FROM eclipse-temurin:21-jdk-jammy AS builder
 
-WORKDIR /workspace
+WORKDIR /app
 
 COPY gradlew .
-COPY gradle/ gradle/
-RUN chmod +x gradlew
-
+COPY gradle gradle
 COPY build.gradle settings.gradle ./
-COPY src/ src/
+
+RUN chmod +x gradlew
 
 ARG GITHUB_USER
 
 RUN --mount=type=secret,id=github_token \
     GITHUB_TOKEN="$(cat /run/secrets/github_token)" \
     GITHUB_USER=$GITHUB_USER \
-    ./gradlew bootJar -x test -x asciidoctor --no-daemon
+    ./gradlew bootJar -x test -x asciidoctor --no-daemon || true
 
-# Stage 2: 런타임 (JRE만 포함한 경량 이미지)
-FROM eclipse-temurin:21-jre-alpine
+COPY src src
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token)" \
+    GITHUB_USER=$GITHUB_USER \
+    ./gradlew clean bootJar -x test -x asciidoctor --no-daemon
+
+RUN java -Djarmode=layertools -jar build/libs/*.jar extract
+
+FROM eclipse-temurin:21-jre-jammy
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash spring
 
 WORKDIR /app
 
-COPY --from=builder /workspace/build/libs/app.jar app.jar
+COPY --from=builder --chown=spring:spring /app/dependencies/ ./
+COPY --from=builder --chown=spring:spring /app/spring-boot-loader/ ./
+COPY --from=builder --chown=spring:spring /app/snapshot-dependencies/ ./
+COPY --from=builder --chown=spring:spring /app/application/ ./
 
-RUN chown appuser:appgroup app.jar
-
-USER appuser
+USER spring
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", \
-  "-XX:+UseContainerSupport", \
-  "-XX:MaxRAMPercentage=75.0", \
-  "-Djava.security.egd=file:/dev/./urandom", \
-  "-jar", "app.jar"]
+ENV JAVA_OPTS=""
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     // ===== common-jpa 공통 JPA 모듈 =====
     // 제공 내용: BaseEntity, BaseUserEntity, CommonJpaAutoConfiguration(@EnableJpaAuditing, JPAQueryFactory),
     // SecurityAuditorAware(X-User-Id 헤더 기반 createdBy/updatedBy 자동 주입)
-    implementation 'com.first-ticket:common-jpa:0.0.1-SNAPSHOT'
+    implementation 'com.first-ticket:common-jpa:0.0.2-SNAPSHOT'
 
 	// ===== Spring Boot Starters =====
 	implementation 'org.springframework.boot:spring-boot-starter-web' // MVC, Tomcat

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,9 @@ spring:
       - "optional:file:.env[.properties]"                    # Working Dir = user-service/  일 때
       - "optional:configserver:"             # URL 없이 Eureka 디스커버리로 Config Server 탐색
 
+  jackson:
+    time-zone: Asia/Seoul
+
   cloud:
     # ECS Fargate에서 Eureka에 자기 IP를 ECS 메타데이터 IP(169.254.172.2)가 아닌 VPC 내부 IP(172.31.x.x)로 등록되게 하기 위한 설정.
     # InetUtils가 IP 선택 시점이 Config Server 받기 전이라


### PR DESCRIPTION
## 🌱 설명

팀 배포 가이드 기준에 맞춰 user-service 배포 관련 설정 3가지를 보완합니다.

- `Dockerfile` 런타임 이미지를 `alpine` → `jammy`로 교체하고 `curl` 설치
- `JAVA_OPTS` 환경 변수를 ECS 태스크 정의에서 주입할 수 있도록 ENTRYPOINT 구조 변경
- 레이어드 JAR 구조로 전환 (의존성/코드 레이어 분리)
- `application.yaml`에 Jackson 타임존 설정 추가 (`Asia/Seoul`)
- CD 파이프라인 트리거에 `dev` 브랜치 추가


## 📌 관련 이슈

- close #56


## 💻 커밋 유형

- [x] chore    : 빌드 설정, 의존성 업데이트 등


## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="📚 추가 설명">📚 추가 설명</h2>
<p><strong>Dockerfile 변경 배경</strong></p>

항목 | 변경 전 | 변경 후 | 이유
-- | -- | -- | --
런타임 이미지 | 21-jre-alpine | 21-jre-jammy | Alpine에 curl 없어 ECS 헬스체크 불가
ENTRYPOINT | 하드코딩 | $JAVA_OPTS 참조 | ECS 태스크 정의에서 JVM 인자 주입 필요
JAR 구조 | fat jar | 레이어드 JAR | 소스 변경 시 의존성 레이어 캐시 재사용


<p><strong>후속 작업 필요</strong><br>
이 PR 머지 후 ECS 태스크 정의에 <code>JAVA_OPTS=-Duser.timezone=Asia/Seoul</code> 환경 변수를 추가해야 타임존 설정이 실제 배포 환경에 적용됩니다.</p><!--EndFragment-->
</body>
</html>
